### PR TITLE
Fix `AnsibleUndefinedVariable` error

### DIFF
--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -192,7 +192,7 @@ jobs:
           ssh-add ~/private.key
       - name: Install Ansible / botocore / boto3
         run: |
-          python3 -m pip install --user ansible
+          python3 -m pip install --user ansible==8.7.0
           python3 -m pip install boto3 botocore
       - name: Configure Ansible
         working-directory: ansible


### PR DESCRIPTION
An error occurred when running Ansible with the following message:

```python
ansible.errors.AnsibleUndefinedVariable: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'tags'
```

This issue appears to be caused by a bug in the latest version of Ansible.

To resolve the issue, the Ansible version was downgraded to `8.7.0` which does not have this bug. After making this change, the playbook executed as expected.