### PR TITLE
Fix `Get latest block number` on Availability Test

### DIFF
--- a/.github/workflows/availability-tests.yml
+++ b/.github/workflows/availability-tests.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Get latest block number
         id: latest_block_number
         run: |
+          set -e
+          curl $rpc_url --max-time 30 > /dev/null 2>&1
           current_block_number=$(cast to-dec `cast rpc --rpc-url $rpc_url eth_blockNumber | sed 's/"//g'`)
           sleep 15
           latest_block_number=$(cast to-dec `cast rpc --rpc-url $rpc_url eth_blockNumber | sed 's/"//g'`)


### PR DESCRIPTION
The `Get latest block number` is failing due to the RPC URL being unavailable, but the job step will still be completed successfully, resulting in a successful Slack notification.

To resolve this issue, we must ensure the RPC URL is available before moving on to the next steps.