### PR TITLE
Introduce bridge transaction type

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,13 @@ issues:
         - wsl
         - lll
         - stylecheck
+    # bridge_tx.go and state_tx.go are currently the same (at some point this will surely change)
+    - path: types/bridge_tx.go
+      linters:
+        - dupl
+    - path: types/state_tx.go
+      linters:
+        - dupl
   include:
     - EXC0012 # Exported (.+) should have comment( \(or a comment on this block\))? or be unexported
     - EXC0013 # Package comment should be of the form "(.+)...

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1043,7 +1043,7 @@ func (b *Blockchain) ReadTxLookup(hash types.Hash) (uint64, bool) {
 // return error if the invalid signature found
 func (b *Blockchain) recoverFromFieldsInBlock(block *types.Block) error {
 	for _, tx := range block.Transactions {
-		if tx.From() != types.ZeroAddress || tx.Type() == types.StateTxType {
+		if tx.From() != types.ZeroAddress || tx.Type() == types.StateTxType || tx.Type() == types.BridgeTxType {
 			continue
 		}
 
@@ -1064,7 +1064,7 @@ func (b *Blockchain) recoverFromFieldsInTransactions(transactions []*types.Trans
 	updated := false
 
 	for _, tx := range transactions {
-		if tx.From() != types.ZeroAddress || tx.Type() == types.StateTxType {
+		if tx.From() != types.ZeroAddress || tx.Type() == types.StateTxType || tx.Type() == types.BridgeTxType {
 			continue
 		}
 

--- a/consensus/polybft/bridge/bridge.go
+++ b/consensus/polybft/bridge/bridge.go
@@ -230,8 +230,8 @@ func (b *bridge) VerifyTransactions(blockInfo oracle.NewBlockInfo, txs []*types.
 	)
 
 	for _, tx := range txs {
-		if tx.Type() != types.StateTxType {
-			continue // not a state transaction, we don't care about it
+		if tx.Type() != types.BridgeTxType {
+			continue // not a bridge transaction, we don't care about it
 		}
 
 		txData := tx.Input()
@@ -301,10 +301,10 @@ func createBridgeBatchTx(internalGatewayAddr types.Address,
 	}
 
 	if signedBridgeBatch.IsE2IBatch() {
-		return helpers.CreateStateTransactionWithData(internalGatewayAddr, inputData), nil
+		return helpers.CreateBridgeTransactionWithData(internalGatewayAddr, inputData), nil
 	}
 
-	return helpers.CreateStateTransactionWithData(contracts.BridgeStorageContract, inputData), nil
+	return helpers.CreateBridgeTransactionWithData(contracts.BridgeStorageContract, inputData), nil
 }
 
 // VerifyBridgeBatchTx validates bridge batch transaction
@@ -377,7 +377,7 @@ func createCommitValidatorSetTxn(bi oracle.NewBlockInfo) (*types.Transaction, er
 		return nil, fmt.Errorf("failed to encode input data for BridgeStorage validator set update: %w", err)
 	}
 
-	return helpers.CreateStateTransactionWithData(contracts.BridgeStorageContract, inputData), nil
+	return helpers.CreateBridgeTransactionWithData(contracts.BridgeStorageContract, inputData), nil
 }
 
 // verifyCommitValidatorSetTx verifies commit validator set state transaction

--- a/consensus/polybft/bridge/bridge_test.go
+++ b/consensus/polybft/bridge/bridge_test.go
@@ -207,7 +207,7 @@ func TestVerifyTransactions(t *testing.T) {
 			},
 			setupMocks: func(bridge *bridge, blockInfo *oracle.NewBlockInfo) []*types.Transaction {
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput([]byte{0, 1, 2}))),
+					types.NewTx(types.NewBridgeTx(types.WithInput([]byte{0, 1, 2}))),
 				}
 			},
 			expectedError: helpers.ErrStateTransactionInputInvalid.Error(),
@@ -224,7 +224,7 @@ func TestVerifyTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 			expectedError: errBridgeBatchTxInNonSprintBlock.Error(),
@@ -246,7 +246,7 @@ func TestVerifyTransactions(t *testing.T) {
 				blockInfo.CurrentEpochValidatorSet = validators.ToValidatorSet()
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 		},
@@ -285,7 +285,7 @@ func TestVerifyTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 		},
@@ -307,7 +307,7 @@ func TestVerifyTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 			expectedError: errCommitValidatorSetTxNotExpected.Error(),
@@ -330,7 +330,7 @@ func TestVerifyTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 			expectedError: errCommitValidatorSetTxInvalid.Error(),
@@ -354,7 +354,7 @@ func TestVerifyTransactions(t *testing.T) {
 				require.NoError(t, err)
 
 				return []*types.Transaction{
-					types.NewTx(types.NewStateTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
+					types.NewTx(types.NewBridgeTx(types.WithInput(input), types.WithTo(&contracts.BridgeStorageContract))),
 				}
 			},
 			expectedError: "missing in the commit validator set transaction",

--- a/consensus/polybft/helpers/runtime_helpers.go
+++ b/consensus/polybft/helpers/runtime_helpers.go
@@ -61,3 +61,17 @@ func CreateStateTransactionWithData(target types.Address, inputData []byte) *typ
 
 	return tx.ComputeHash()
 }
+
+// CreateBridgeTransactionWithData creates a bridge transaction
+// with provided target address and inputData parameter which is ABI encoded byte array.
+func CreateBridgeTransactionWithData(target types.Address, inputData []byte) *types.Transaction {
+	tx := types.NewTx(types.NewBridgeTx(
+		types.WithGasPrice(big.NewInt(0)),
+		types.WithFrom(contracts.SystemCaller),
+		types.WithTo(&target),
+		types.WithInput(inputData),
+		types.WithGas(types.StateTransactionGasLimit),
+	))
+
+	return tx.ComputeHash()
+}

--- a/consensus/polybft/polybft.go
+++ b/consensus/polybft/polybft.go
@@ -733,18 +733,18 @@ func (p *Polybft) PreCommitState(block *types.Block, _ *state.Transition) error 
 		return err
 	}
 
-	// validate bridge batch state transactions
+	// validate bridge transactions
 	for _, tx := range block.Transactions {
-		if tx.Type() != types.StateTxType {
+		if tx.Type() != types.BridgeTxType {
 			continue
 		}
 
-		decodedStateTx, err := decodeStateTransaction(tx.Input())
+		decodedBridgeTx, err := decodeStateTransaction(tx.Input())
 		if err != nil {
 			return fmt.Errorf("unknown state transaction: tx=%v, error: %w", tx.Hash(), err)
 		}
 
-		if signedBridgeBatch, ok := decodedStateTx.(*bridge.BridgeBatchSigned); ok {
+		if signedBridgeBatch, ok := decodedBridgeTx.(*bridge.BridgeBatchSigned); ok {
 			if err := bridge.VerifyBridgeBatchTx(
 				block.Number(),
 				tx.Hash(),

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -82,7 +82,7 @@ func (signer *EIP155Signer) Hash(tx *types.Transaction) types.Hash {
 
 // Sender returns the sender of the transaction
 func (signer *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return types.ZeroAddress, types.ErrTxTypeNotSupported
 	}
 
@@ -120,7 +120,7 @@ func (signer *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error)
 
 // SignTx takes the original transaction as input and returns its signed version
 func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
@@ -144,7 +144,7 @@ func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 
 func (signer *EIP155Signer) SignTxWithCallback(tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return nil, types.ErrTxTypeNotSupported
 	}
 

--- a/crypto/txsigner_eip155.go
+++ b/crypto/txsigner_eip155.go
@@ -82,7 +82,7 @@ func (signer *EIP155Signer) Hash(tx *types.Transaction) types.Hash {
 
 // Sender returns the sender of the transaction
 func (signer *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return types.ZeroAddress, types.ErrTxTypeNotSupported
 	}
 
@@ -120,7 +120,7 @@ func (signer *EIP155Signer) Sender(tx *types.Transaction) (types.Address, error)
 
 // SignTx takes the original transaction as input and returns its signed version
 func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
@@ -144,7 +144,7 @@ func (signer *EIP155Signer) SignTx(tx *types.Transaction, privateKey *ecdsa.Priv
 
 func (signer *EIP155Signer) SignTxWithCallback(tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
 

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -71,7 +71,7 @@ func (signer *FrontierSigner) Sender(tx *types.Transaction) (types.Address, erro
 
 // sender returns the sender of the transaction
 func (signer *FrontierSigner) sender(tx *types.Transaction, isHomestead bool) (types.Address, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return types.ZeroAddress, types.ErrTxTypeNotSupported
 	}
 
@@ -97,7 +97,7 @@ func (signer *FrontierSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.Pr
 // signTxInternal takes the original transaction as input and returns its signed version
 func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 	privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
@@ -117,7 +117,7 @@ func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 func (signer *FrontierSigner) SignTxWithCallback(
 	tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
+	if !IsLegacyLikeTx(tx) {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
@@ -144,4 +144,8 @@ func (signer *FrontierSigner) calculateV(parity byte) []byte {
 	result.Add(big.NewInt(int64(parity)), big27)
 
 	return result.Bytes()
+}
+
+func IsLegacyLikeTx(tx *types.Transaction) bool {
+	return tx.Type() == types.LegacyTxType || tx.Type() == types.StateTxType || tx.Type() == types.BridgeTxType
 }

--- a/crypto/txsigner_frontier.go
+++ b/crypto/txsigner_frontier.go
@@ -71,7 +71,7 @@ func (signer *FrontierSigner) Sender(tx *types.Transaction) (types.Address, erro
 
 // sender returns the sender of the transaction
 func (signer *FrontierSigner) sender(tx *types.Transaction, isHomestead bool) (types.Address, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return types.ZeroAddress, types.ErrTxTypeNotSupported
 	}
 
@@ -97,7 +97,7 @@ func (signer *FrontierSigner) SignTx(tx *types.Transaction, privateKey *ecdsa.Pr
 // signTxInternal takes the original transaction as input and returns its signed version
 func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 	privateKey *ecdsa.PrivateKey) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
 
@@ -117,7 +117,7 @@ func (signer *FrontierSigner) signTxInternal(tx *types.Transaction,
 func (signer *FrontierSigner) SignTxWithCallback(
 	tx *types.Transaction,
 	signFn func(hash types.Hash) (sig []byte, err error)) (*types.Transaction, error) {
-	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType {
+	if tx.Type() != types.LegacyTxType && tx.Type() != types.StateTxType && tx.Type() != types.BridgeTxType {
 		return nil, types.ErrTxTypeNotSupported
 	}
 

--- a/crypto/txsigner_london_test.go
+++ b/crypto/txsigner_london_test.go
@@ -56,6 +56,16 @@ func TestLondonSignerSender(t *testing.T) {
 			types.StateTxType,
 		},
 		{
+			"kovan",
+			big.NewInt(42),
+			types.BridgeTxType,
+		},
+		{
+			"geth private",
+			big.NewInt(1337),
+			types.BridgeTxType,
+		},
+		{
 			"mega large",
 			big.NewInt(0).Exp(big.NewInt(2), big.NewInt(20), nil), // 2**20
 			types.AccessListTxType,
@@ -88,6 +98,12 @@ func TestLondonSignerSender(t *testing.T) {
 				))
 			case types.StateTxType:
 				txn = types.NewTx(types.NewStateTx(
+					types.WithGasPrice(big.NewInt(5)),
+					types.WithTo(&recipient),
+					types.WithValue(big.NewInt(1)),
+				))
+			case types.BridgeTxType:
+				txn = types.NewTx(types.NewBridgeTx(
 					types.WithGasPrice(big.NewInt(5)),
 					types.WithTo(&recipient),
 					types.WithValue(big.NewInt(1)),

--- a/loadtest/runner/base_load_test_runner.go
+++ b/loadtest/runner/base_load_test_runner.go
@@ -287,7 +287,8 @@ func (r *BaseLoadTestRunner) waitForReceiptsParallel() {
 				continue
 			}
 
-			if (len(block.Transactions) == 1 && block.Transactions[0].Type() == types.StateTxType) ||
+			if (len(block.Transactions) == 1 && block.Transactions[0].Type() == types.StateTxType ||
+				block.Transactions[0].Type() == types.BridgeTxType) ||
 				len(block.Transactions) == 0 {
 				sequentialEmptyBlocks++
 				currentBlock++

--- a/state/executor.go
+++ b/state/executor.go
@@ -177,7 +177,7 @@ func (e *Executor) ProcessBlock(
 			return nil, runtime.ErrOutOfGas
 		}
 
-		if t.From() == emptyFrom && t.Type() != types.StateTxType {
+		if t.From() == emptyFrom && t.Type() != types.StateTxType && t.Type() != types.BridgeTxType {
 			if poolTx, ok := e.GetPendingTxHook(t.Hash()); ok {
 				t.SetFrom(poolTx.From())
 			}
@@ -387,7 +387,7 @@ var emptyFrom = types.Address{}
 
 // Write writes another transaction to the executor
 func (t *Transition) Write(txn *types.Transaction) error {
-	if txn.From() == emptyFrom && txn.Type() != types.StateTxType {
+	if txn.From() == emptyFrom && txn.Type() != types.StateTxType && txn.Type() != types.BridgeTxType {
 		// Decrypt the from address
 		signer := crypto.NewSigner(t.config, uint64(t.ctx.ChainID))
 
@@ -665,7 +665,7 @@ func NewGasLimitReachedTransitionApplicationError(err error) *GasLimitReachedTra
 func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, error) {
 	var err error
 
-	if msg.Type() == types.StateTxType {
+	if msg.Type() == types.StateTxType || msg.Type() == types.BridgeTxType {
 		err = checkAndProcessStateTx(msg)
 	} else {
 		err = checkAndProcessTx(msg, t)
@@ -764,7 +764,8 @@ func (t *Transition) apply(msg *types.Transaction) (*runtime.ExecutionResult, er
 
 	// Burn some amount if the london hardfork is applied and token is non mintable.
 	// Basically, burn amount is just transferred to the current burn contract.
-	if t.isL1OriginatedToken && t.config.London && msg.Type() != types.StateTxType {
+	if t.isL1OriginatedToken && t.config.London && msg.Type() != types.StateTxType &&
+		msg.Type() != types.BridgeTxType {
 		burnAmount := new(big.Int).Mul(new(big.Int).SetUint64(result.GasUsed), t.ctx.BaseFee)
 		t.state.AddBalance(t.ctx.BurnContract, burnAmount)
 	}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -639,11 +639,11 @@ func (p *TxPool) ClearProposed() {
 // validateTx ensures the transaction conforms to specific
 // constraints before entering the pool.
 func (p *TxPool) validateTx(tx *types.Transaction) error {
-	// Check the transaction type. State transactions are not expected to be added to the pool
-	if tx.Type() == types.StateTxType {
+	// Check the transaction type. State/bridge transactions are not expected to be added to the pool
+	if tx.Type() == types.StateTxType || tx.Type() == types.BridgeTxType {
 		metrics.IncrCounter([]string{txPoolMetrics, "invalid_tx_type"}, 1)
 
-		return fmt.Errorf("%w: type %d rejected, state transactions are not expected to be added to the pool",
+		return fmt.Errorf("%w: type %d rejected, state/bridge transactions are not expected to be added to the pool",
 			ErrInvalidTxType, tx.Type())
 	}
 

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -157,9 +157,9 @@ func TestAddTxErrors(t *testing.T) {
 
 		pool := setupPool()
 
-		tx := newTx(defaultAddr, 0, 1, types.StateTxType)
+		stateTx := newTx(defaultAddr, 0, 1, types.StateTxType)
 
-		err := pool.addTx(local, signTx(tx))
+		err := pool.addTx(local, signTx(stateTx))
 
 		assert.ErrorContains(t,
 			err,
@@ -167,7 +167,20 @@ func TestAddTxErrors(t *testing.T) {
 		)
 		assert.ErrorContains(t,
 			err,
-			"state transactions are not expected to be added to the pool",
+			"state/bridge transactions are not expected to be added to the pool",
+		)
+
+		bridgeTx := newTx(defaultAddr, 0, 1, types.BridgeTxType)
+
+		err = pool.addTx(local, signTx(bridgeTx))
+
+		assert.ErrorContains(t,
+			err,
+			ErrInvalidTxType.Error(),
+		)
+		assert.ErrorContains(t,
+			err,
+			"state/bridge transactions are not expected to be added to the pool",
 		)
 	})
 

--- a/types/bridge_tx.go
+++ b/types/bridge_tx.go
@@ -1,0 +1,232 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/umbracle/fastrlp"
+	"github.com/valyala/fastjson"
+)
+
+type BridgeTx struct {
+	*BaseTx
+	GasPrice *big.Int
+}
+
+func NewBridgeTx(options ...TxOption) *BridgeTx {
+	bridgeTx := &BridgeTx{BaseTx: &BaseTx{}}
+
+	for _, opt := range options {
+		opt(bridgeTx)
+	}
+
+	return bridgeTx
+}
+
+func (tx *BridgeTx) transactionType() TxType { return BridgeTxType }
+func (tx *BridgeTx) chainID() *big.Int       { return deriveChainID(tx.v()) }
+func (tx *BridgeTx) gasPrice() *big.Int      { return tx.GasPrice }
+func (tx *BridgeTx) gasTipCap() *big.Int     { return tx.GasPrice }
+func (tx *BridgeTx) gasFeeCap() *big.Int     { return tx.GasPrice }
+func (tx *BridgeTx) effectiveGasPrice(baseFee *big.Int) *big.Int {
+	return new(big.Int).Set(tx.gasPrice())
+}
+
+func (tx *BridgeTx) accessList() TxAccessList {
+	return nil
+}
+
+// set methods for transaction fields
+func (tx *BridgeTx) setChainID(id *big.Int) {}
+
+func (tx *BridgeTx) setGasPrice(gas *big.Int) {
+	tx.GasPrice = gas
+}
+
+func (tx *BridgeTx) setGasFeeCap(gas *big.Int) {
+	tx.GasPrice = gas
+}
+
+func (tx *BridgeTx) setGasTipCap(gas *big.Int) {
+	tx.GasPrice = gas
+}
+
+func (tx *BridgeTx) setAccessList(accessList TxAccessList) {}
+
+// unmarshalRLPFrom unmarshals a Transaction in RLP format
+// Be careful! This function does not de-serialize tx type, it assumes that t.Type is already set
+// Hash calculation should also be done from the outside!
+// Use UnmarshalRLP in most cases
+func (tx *BridgeTx) unmarshalRLPFrom(p *fastrlp.Parser, v *fastrlp.Value) error {
+	numOfElems := 10
+
+	var (
+		values rlpValues
+		err    error
+	)
+
+	values, err = v.GetElems()
+	if err != nil {
+		return err
+	}
+
+	if numElems := len(values); numElems != numOfElems {
+		return fmt.Errorf("incorrect number of transaction elements, expected %d but found %d", numOfElems, numElems)
+	}
+
+	// nonce
+	txNonce, err := values.dequeueValue().GetUint64()
+	if err != nil {
+		return err
+	}
+
+	tx.setNonce(txNonce)
+
+	// gasPrice
+	txGasPrice := new(big.Int)
+	if err = values.dequeueValue().GetBigInt(txGasPrice); err != nil {
+		return err
+	}
+
+	tx.setGasPrice(txGasPrice)
+
+	// gas
+	txGas, err := values.dequeueValue().GetUint64()
+	if err != nil {
+		return err
+	}
+
+	tx.setGas(txGas)
+
+	// to
+	if vv, _ := values.dequeueValue().Bytes(); len(vv) == 20 {
+		// address
+		addr := BytesToAddress(vv)
+		tx.setTo(&addr)
+	} else {
+		// reset To
+		tx.setTo(nil)
+	}
+
+	// value
+	txValue := new(big.Int)
+	if err = values.dequeueValue().GetBigInt(txValue); err != nil {
+		return err
+	}
+
+	tx.setValue(txValue)
+
+	// input
+	var txInput []byte
+
+	txInput, err = values.dequeueValue().GetBytes(txInput)
+	if err != nil {
+		return err
+	}
+
+	tx.setInput(txInput)
+
+	// V
+	txV := new(big.Int)
+	if err = values.dequeueValue().GetBigInt(txV); err != nil {
+		return err
+	}
+
+	// R
+	txR := new(big.Int)
+	if err = values.dequeueValue().GetBigInt(txR); err != nil {
+		return err
+	}
+
+	// S
+	txS := new(big.Int)
+	if err = values.dequeueValue().GetBigInt(txS); err != nil {
+		return err
+	}
+
+	tx.setSignatureValues(txV, txR, txS)
+
+	tx.setFrom(ZeroAddress)
+
+	// We need to set From field for state transaction,
+	// because we are using unique, predefined address, for sending such transactions
+	if vv, err := values.dequeueValue().Bytes(); err == nil && len(vv) == AddressLength {
+		// address
+		tx.setFrom(BytesToAddress(vv))
+	}
+
+	return nil
+}
+
+// MarshalRLPWith marshals the transaction to RLP with a specific fastrlp.Arena
+// Be careful! This function does not serialize tx type as a first byte.
+// Use MarshalRLP/MarshalRLPTo in most cases
+func (tx *BridgeTx) marshalRLPWith(arena *fastrlp.Arena) *fastrlp.Value {
+	vv := arena.NewArray()
+
+	vv.Set(arena.NewUint(tx.nonce()))
+	vv.Set(arena.NewBigInt(tx.gasPrice()))
+	vv.Set(arena.NewUint(tx.gas()))
+	// Address may be empty
+	if tx.to() != nil {
+		vv.Set(arena.NewCopyBytes(tx.to().Bytes()))
+	} else {
+		vv.Set(arena.NewNull())
+	}
+
+	vv.Set(arena.NewBigInt(tx.value()))
+	vv.Set(arena.NewCopyBytes(tx.input()))
+
+	// signature values
+	v, r, s := tx.rawSignatureValues()
+	vv.Set(arena.NewBigInt(v))
+	vv.Set(arena.NewBigInt(r))
+	vv.Set(arena.NewBigInt(s))
+
+	vv.Set(arena.NewCopyBytes(tx.from().Bytes()))
+
+	return vv
+}
+
+func (tx *BridgeTx) copy() TxData {
+	cpy := NewStateTx()
+
+	if tx.gasPrice() != nil {
+		gasPrice := new(big.Int)
+		gasPrice.Set(tx.gasPrice())
+
+		cpy.setGasPrice(gasPrice)
+	}
+
+	cpy.BaseTx = tx.BaseTx.copy()
+
+	return cpy
+}
+
+func (tx *BridgeTx) marshalJSON(a *fastjson.Arena) *fastjson.Value {
+	v := a.NewObject()
+
+	tx.BaseTx.marshalJSON(a, v)
+	v.Set("type", a.NewString(tx.transactionType().ToHexString()))
+
+	if tx.GasPrice != nil {
+		v.Set("gasPrice", a.NewString(fmt.Sprintf("0x%x", tx.GasPrice)))
+	}
+
+	return v
+}
+
+func (tx *BridgeTx) unmarshalJSON(v *fastjson.Value) error {
+	if err := tx.BaseTx.unmarshalJSON(v); err != nil {
+		return err
+	}
+
+	gasPrice, err := UnmarshalJSONBigInt(v, "gasPrice")
+	if err != nil {
+		return err
+	}
+
+	tx.setGasPrice(gasPrice)
+
+	return nil
+}

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -170,6 +170,20 @@ func TestRLPMarshall_And_Unmarshall_TypedTransaction(t *testing.T) {
 				R:     big.NewInt(27),
 			},
 		}),
+		NewTx(&BridgeTx{
+			GasPrice: big.NewInt(11),
+			BaseTx: &BaseTx{
+				Nonce: 0,
+				Gas:   11,
+				To:    &addrTo,
+				From:  addrFrom,
+				Value: big.NewInt(1),
+				Input: []byte{1, 2},
+				V:     big.NewInt(25),
+				S:     big.NewInt(26),
+				R:     big.NewInt(27),
+			},
+		}),
 		NewTx(&LegacyTx{
 			GasPrice: big.NewInt(11),
 			BaseTx: &BaseTx{
@@ -245,6 +259,7 @@ func TestRLPMarshall_Unmarshall_Missing_Data(t *testing.T) {
 
 	txTypes := []TxType{
 		StateTxType,
+		BridgeTxType,
 		LegacyTxType,
 		DynamicFeeTxType,
 	}
@@ -330,6 +345,10 @@ func TestRLPMarshall_And_Unmarshall_TxType(t *testing.T) {
 		{
 			name:   "StateTx",
 			txType: StateTxType,
+		},
+		{
+			name:   "BridgeTx",
+			txType: BridgeTxType,
 		},
 		{
 			name:   "LegacyTx",

--- a/types/rlp_encoding_test.go
+++ b/types/rlp_encoding_test.go
@@ -289,9 +289,9 @@ func TestRLPMarshall_Unmarshall_Missing_Data(t *testing.T) {
 					"GasFeeCap":  txType != DynamicFeeTxType,
 					"GasPrice":   txType == DynamicFeeTxType,
 					"AccessList": txType != DynamicFeeTxType,
-					"From":       txType != StateTxType,
+					"From":       (txType != StateTxType && txType != BridgeTxType),
 				},
-				fromAddrSet: txType == StateTxType,
+				fromAddrSet: (txType == StateTxType || txType == BridgeTxType),
 			},
 			{
 				name:        fmt.Sprintf("[%s] Address set for state tx only", txType),
@@ -302,9 +302,9 @@ func TestRLPMarshall_Unmarshall_Missing_Data(t *testing.T) {
 					"GasFeeCap":  txType != DynamicFeeTxType,
 					"GasPrice":   txType == DynamicFeeTxType,
 					"AccessList": txType != DynamicFeeTxType,
-					"From":       txType != StateTxType,
+					"From":       (txType != StateTxType && txType != BridgeTxType),
 				},
-				fromAddrSet: txType == StateTxType,
+				fromAddrSet: (txType == StateTxType || txType == BridgeTxType),
 			},
 		}
 

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -14,6 +14,8 @@ import (
 const (
 	// StateTransactionGasLimit is arbitrary default gas limit for state transactions
 	StateTransactionGasLimit = 5000000
+	// BridgeTransactionGasLimit is arbitrary default gas limit for state transactions
+	BridgeTransactionGasLimit = 5000000
 )
 
 // TxType is the transaction type.
@@ -24,6 +26,7 @@ const (
 	LegacyTxType     TxType = 0x0
 	AccessListTxType TxType = 0x01
 	DynamicFeeTxType TxType = 0x02
+	BridgeTxType     TxType = 0x7e
 	StateTxType      TxType = 0x7f
 )
 
@@ -31,7 +34,7 @@ func txTypeFromByte(b byte) (TxType, error) {
 	tt := TxType(b)
 
 	switch tt {
-	case LegacyTxType, StateTxType, DynamicFeeTxType, AccessListTxType:
+	case LegacyTxType, StateTxType, BridgeTxType, DynamicFeeTxType, AccessListTxType:
 		return tt, nil
 	default:
 		return tt, fmt.Errorf("unknown transaction type: %d", b)
@@ -45,6 +48,8 @@ func (t TxType) String() (s string) {
 		return "LegacyTx"
 	case StateTxType:
 		return "StateTx"
+	case BridgeTxType:
+		return "BridgeTx"
 	case DynamicFeeTxType:
 		return "DynamicFeeTx"
 	case AccessListTxType:
@@ -85,6 +90,8 @@ func (t *Transaction) InitInnerData(txType TxType) {
 		t.Inner = NewAccessListTx()
 	case StateTxType:
 		t.Inner = NewStateTx()
+	case BridgeTxType:
+		t.Inner = NewBridgeTx()
 	case LegacyTxType:
 		t.Inner = NewLegacyTx()
 	default:


### PR DESCRIPTION
# Description

This PR replaces the usage of state transactions in the bridge logic with bridge transactions. The two transaction types function identically, but bridge transactions are now explicitly used for bridge operations, while state transactions remain in the system for other purposes. Additionally, tests for bridge transactions have been added, mirroring the existing tests for state transactions due to their identical behavior. A linter flag `dup` has been introduced for `types/state_tx.go` and `types/bridge_tx.go`, as they currently contain the same code, though this will be refactored in the future.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
