### PR TITLE
Txpool journal

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -383,6 +383,7 @@ func NewServer(config *Config) (*Server, error) {
 				PriceLimit:         m.config.PriceLimit,
 				MaxAccountEnqueued: m.config.MaxAccountEnqueued,
 				TxGossipBatchSize:  m.config.TxGossipBatchSize,
+				DataDir:            m.config.DataDir,
 				ChainID:            big.NewInt(m.config.Chain.Params.ChainID),
 				PeerID:             m.network.AddrInfo().ID,
 			},
@@ -425,11 +426,6 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	// setup and start jsonrpc server
-	if err := m.setupJSONRPC(); err != nil {
-		return nil, err
-	}
-
 	// restore archive data before starting
 	if err := m.restoreChain(); err != nil {
 		return nil, err
@@ -440,8 +436,14 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, err
 	}
 
+	// start txpool
 	m.txpool.SetBaseFee(m.blockchain.Header())
 	m.txpool.Start()
+
+	// setup and start jsonrpc server
+	if err := m.setupJSONRPC(); err != nil {
+		return nil, err
+	}
 
 	return m, nil
 }

--- a/txpool/journal.go
+++ b/txpool/journal.go
@@ -72,7 +72,7 @@ func (j *journal) load(add func(*types.Transaction) error) error {
 	j.writer = new(devNull)
 	defer func() { j.writer = nil }()
 
-	total, dropped := 0, 0
+	dropped := 0
 	// inject all transactions from the journal into the pool
 	for _, tx := range txs {
 		if err := add(tx); err != nil {
@@ -80,11 +80,9 @@ func (j *journal) load(add func(*types.Transaction) error) error {
 
 			j.logger.Debug("failed to add journaled transaction", "err", err)
 		}
-
-		total++
 	}
 
-	j.logger.Info("loaded local transaction journal", "transactions", total, "dropped", dropped)
+	j.logger.Info("loaded local transaction journal", "transactions", len(txs), "dropped", dropped)
 
 	return nil
 }

--- a/txpool/journal.go
+++ b/txpool/journal.go
@@ -1,0 +1,172 @@
+package txpool
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
+)
+
+// number of txs in journal when rotate will be executed
+const journalRotate = 1000
+
+// devNull is a WriteCloser that just discards anything written into it. Its
+// goal is to allow the transaction journal to write into a fake journal when
+// loading transactions on startup without printing warnings due to no file
+// being read for write.
+type devNull struct{}
+
+func (*devNull) Write(p []byte) (n int, err error) { return len(p), nil }
+func (*devNull) Close() error                      { return nil }
+
+// journal is a rotating log of transactions with the aim of storing locally
+// created transactions to allow non-executed ones to survive node restarts.
+type journal struct {
+	path   string         // filesystem path to store the transactions at
+	writer io.WriteCloser // output stream to write new transactions into
+	logger hclog.Logger   // logger
+	count  uint32         // number of txs in journal
+	lock   sync.Mutex     // used for journal locking during rotation
+
+	journalCh chan struct{} // used for sending journal rotation events to txpool
+}
+
+// newTxJournal creates a new transaction journal to
+func newTxJournal(path string, logger hclog.Logger, journalCh chan struct{}) *journal {
+	return &journal{
+		path:      path,
+		logger:    logger,
+		journalCh: journalCh,
+	}
+}
+
+// load parses a transaction journal dump from disk, loading its contents into
+// the specified pool.
+func (j *journal) load(add func(*types.Transaction) error) error {
+	// open the journal for loading any past transactions
+	data, err := os.ReadFile(j.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		// skip the parsing if the journal file doesn't exist at all
+		return nil
+	}
+
+	// decode txs
+	txs := &types.Transactions{}
+	if err := txs.UnmarshalRLP(data); err != nil {
+		j.logger.Error("failed to decode journaled tx", "err", err)
+
+		return err
+	}
+
+	// temporarily discard any journal additions (don't double add on load)
+	j.writer = new(devNull)
+	defer func() { j.writer = nil }()
+
+	// inject all transactions from the journal into the pool
+	total, dropped := 0, 0
+
+	for _, tx := range *txs {
+		if err := add(tx); err != nil {
+			dropped++
+
+			j.logger.Debug("failed to add journaled transaction", "err", err)
+		}
+
+		total++
+	}
+
+	j.logger.Info("loaded local transaction journal", "transactions", total, "dropped", dropped)
+
+	return nil
+}
+
+// insert adds the specified transaction to the local disk journal.
+func (j *journal) insert(tx *types.Transaction) error {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+
+	if j.writer == nil {
+		return errors.New("no active journal")
+	}
+
+	_, err := j.writer.Write(tx.MarshalRLP())
+	if err == nil {
+		// this has to be atomic
+		if atomic.AddUint32(&j.count, 1) == journalRotate {
+			// send event
+			j.journalCh <- struct{}{}
+		}
+	}
+
+	return err
+}
+
+// rotate regenerates the transaction journal based on the current contents of
+// the transaction pool.
+func (j *journal) rotate(local []*types.Transaction) error {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+
+	// close the current journal (if any is open)
+	if j.writer != nil {
+		if err := j.writer.Close(); err != nil {
+			return err
+		}
+
+		j.writer = nil
+	}
+
+	// generate a new journal with the contents of the current pool
+	replacement, err := os.OpenFile(j.path+".new", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+
+	// fill a new journal with txs from the pool
+	for _, tx := range local {
+		_, err := replacement.Write(tx.MarshalRLP())
+		if err != nil {
+			replacement.Close()
+
+			return err
+		}
+	}
+
+	replacement.Close()
+
+	// replace the live journal with the newly generated one
+	if err = os.Rename(j.path+".new", j.path); err != nil {
+		return err
+	}
+
+	// open a new journal
+	sink, err := os.OpenFile(j.path, os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+
+	// this reset is under mutex
+	j.count = 0
+	j.writer = sink
+
+	j.logger.Info("regenerated local transaction journal", "transactions", len(local))
+
+	return nil
+}
+
+// close flushes the transaction journal contents to disk and closes the file.
+func (j *journal) close() error {
+	var err error
+
+	if j.writer != nil {
+		err = j.writer.Close()
+		j.writer = nil
+	}
+
+	return err
+}

--- a/txpool/journal.go
+++ b/txpool/journal.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"sync"
-	"sync/atomic"
 
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -101,8 +100,8 @@ func (j *journal) insert(tx *types.Transaction) error {
 
 	_, err := j.writer.Write(tx.MarshalRLP())
 	if err == nil {
-		// this has to be atomic
-		if atomic.AddUint32(&j.count, 1) == journalRotate {
+		j.count++
+		if j.count == journalRotate {
 			// send event
 			j.journalCh <- struct{}{}
 		}

--- a/txpool/journal.go
+++ b/txpool/journal.go
@@ -55,22 +55,27 @@ func (j *journal) load(add func(*types.Transaction) error) error {
 		return nil
 	}
 
+	txs := make([]*types.Transaction, 0)
 	// decode txs
-	txs := &types.Transactions{}
-	if err := txs.UnmarshalRLP(data); err != nil {
-		j.logger.Error("failed to decode journaled tx", "err", err)
+	for len(data) > 0 {
+		tx := &types.Transaction{}
+		if err := tx.UnmarshalRLP(data); err != nil {
+			j.logger.Error("failed to decode journaled tx", "err", err)
 
-		return err
+			return err
+		}
+
+		data = data[tx.Size():]
+		txs = append(txs, tx)
 	}
 
 	// temporarily discard any journal additions (don't double add on load)
 	j.writer = new(devNull)
 	defer func() { j.writer = nil }()
 
-	// inject all transactions from the journal into the pool
 	total, dropped := 0, 0
-
-	for _, tx := range *txs {
+	// inject all transactions from the journal into the pool
+	for _, tx := range txs {
 		if err := add(tx); err != nil {
 			dropped++
 

--- a/txpool/journal_test.go
+++ b/txpool/journal_test.go
@@ -1,0 +1,127 @@
+package txpool
+
+import (
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJournalLoad(t *testing.T) {
+	t.Parallel()
+
+	path, err := os.MkdirTemp("", "txpool")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(path)
+
+	addrTo := types.StringToAddress("11")
+
+	originalTxs := []*types.Transaction{
+		types.NewTx(&types.StateTx{
+			GasPrice: big.NewInt(11),
+			BaseTx: &types.BaseTx{
+				Nonce: 1,
+				Gas:   11,
+				To:    &addrTo,
+				From:  types.StringToAddress("1"),
+				Value: big.NewInt(1),
+				Input: []byte{1, 2},
+				V:     big.NewInt(25),
+				S:     big.NewInt(26),
+				R:     big.NewInt(27),
+			},
+		}),
+		types.NewTx(&types.LegacyTx{
+			GasPrice: big.NewInt(11),
+			BaseTx: &types.BaseTx{
+				Nonce: 2,
+				Gas:   11,
+				To:    &addrTo,
+				From:  types.StringToAddress("2"),
+				Value: big.NewInt(2),
+				Input: []byte{1, 2},
+				V:     big.NewInt(25),
+				S:     big.NewInt(26),
+				R:     big.NewInt(27),
+			},
+		}),
+		types.NewTx(&types.DynamicFeeTx{
+			GasFeeCap: big.NewInt(12),
+			GasTipCap: big.NewInt(13),
+			BaseTx: &types.BaseTx{
+				Nonce: 3,
+				Gas:   11,
+				To:    &addrTo,
+				From:  types.StringToAddress("3"),
+				Value: big.NewInt(3),
+				Input: []byte{1, 2},
+				V:     big.NewInt(25),
+				S:     big.NewInt(26),
+				R:     big.NewInt(27),
+			},
+		}),
+	}
+
+	// init journal
+	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), make(chan struct{}))
+
+	// add txs into journal with rotate
+	require.NoError(t, journal.rotate(originalTxs))
+
+	// insert into journal
+	for _, tx := range originalTxs {
+		require.NoError(t, journal.insert(tx))
+	}
+
+	resultTxs := make([]*types.Transaction, 0)
+	// load journal
+	require.NoError(t, journal.load(func(tx *types.Transaction) error {
+		resultTxs = append(resultTxs, tx)
+
+		return nil
+	}))
+
+	require.Len(t, resultTxs, len(originalTxs)*2)
+
+	for i, tx := range originalTxs {
+		require.Equal(t, tx.Hash(), resultTxs[i].Hash())
+		require.Equal(t, tx.Hash(), resultTxs[len(originalTxs)+i].Hash())
+	}
+
+	require.NoError(t, journal.close())
+}
+
+func TestJournalRotate(t *testing.T) {
+	t.Parallel()
+
+	path, err := os.MkdirTemp("", "txpool")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(path)
+
+	// create journal
+	rotateCh := make(chan struct{})
+	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), rotateCh)
+
+	// init journal
+	require.NoError(t, journal.rotate([]*types.Transaction{}))
+
+	// start routine
+	go func() {
+		<-rotateCh
+
+		return
+	}()
+
+	// add txs into journal until rotate event is fired
+	for range journalRotate {
+		require.NoError(t, journal.insert(newTx(addr1, 1, 1, types.LegacyTxType)))
+	}
+
+	require.NoError(t, journal.close())
+}

--- a/txpool/lookup_map.go
+++ b/txpool/lookup_map.go
@@ -52,8 +52,8 @@ func (m *lookupMap) get(hash types.Hash) (*types.Transaction, bool) {
 
 // local returns local transactions from the map. [thread-safe]
 func (m *lookupMap) local() []*types.Transaction {
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 
 	txs := make([]*types.Transaction, 0)
 

--- a/txpool/lookup_map.go
+++ b/txpool/lookup_map.go
@@ -49,3 +49,19 @@ func (m *lookupMap) get(hash types.Hash) (*types.Transaction, bool) {
 
 	return tx, true
 }
+
+// local returns local transactions from the map. [thread-safe]
+func (m *lookupMap) local() []*types.Transaction {
+	m.Lock()
+	defer m.Unlock()
+
+	txs := make([]*types.Transaction, 0)
+
+	for _, tx := range m.all {
+		if tx.IsLocal {
+			txs = append(txs, tx)
+		}
+	}
+
+	return txs
+}

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/0xPolygon/polygon-edge/chain"
+	"github.com/0xPolygon/polygon-edge/helper/common"
 	"github.com/0xPolygon/polygon-edge/network"
 	"github.com/0xPolygon/polygon-edge/state"
 	"github.com/0xPolygon/polygon-edge/state/runtime"
@@ -104,6 +106,7 @@ type Config struct {
 	TxGossipBatchSize  uint64
 	ChainID            *big.Int
 	PeerID             peer.ID
+	DataDir            string
 }
 
 /* All requests are passed to the main loop
@@ -200,6 +203,15 @@ type TxPool struct {
 
 	// WG for batch flushing
 	gossipWG sync.WaitGroup
+
+	// journal for local txs
+	journal *journal
+
+	// journal channel
+	journalCh chan struct{}
+
+	// data dir
+	dataDir string
 }
 
 const batchersNum = 1
@@ -224,12 +236,14 @@ func NewTxPool(
 		priceLimit:        config.PriceLimit,
 		chainID:           config.ChainID,
 		localPeerID:       config.PeerID,
+		dataDir:           config.DataDir,
 		txGossipBatchSize: int(config.TxGossipBatchSize),
 
 		//	main loop channels
 		promoteReqCh: make(chan promoteRequest),
 		pruneCh:      make(chan struct{}),
 		shutdownCh:   make(chan struct{}),
+		journalCh:    make(chan struct{}),
 		gossipCh:     make(chan *types.Transaction, 4*batchersNum*config.TxGossipBatchSize),
 	}
 
@@ -263,7 +277,7 @@ func (p *TxPool) updatePending(i int64) {
 }
 
 func (p *TxPool) startGossipBatchers() {
-	for i := 0; i < batchersNum; i++ {
+	for range batchersNum {
 		p.gossipWG.Add(1)
 
 		go p.gossipBatcher()
@@ -329,6 +343,39 @@ func (p *TxPool) publish(batch *[]*types.Transaction) {
 	clear(*batch)
 }
 
+func (p *TxPool) startJournal() {
+	journalDir := "txpool"
+	if err := common.SetupDataDir(p.dataDir, []string{journalDir}, 0770); err != nil {
+		p.logger.Error("txpool journal directory setup failed", "err", err)
+	}
+
+	p.journal = newTxJournal(filepath.Join(p.dataDir, journalDir, "transactions.rlp"), p.logger, p.journalCh)
+
+	if err := p.journal.load(func(tx *types.Transaction) error {
+		return p.AddTx(tx)
+	}); err != nil {
+		p.logger.Error("journal loading failed", "err", err)
+	}
+
+	if err := p.journal.rotate(p.index.local()); err != nil {
+		p.logger.Error("initial journal rotation failed", "err", err)
+	}
+
+	// run the handler for journal rotation
+	go func() {
+		for {
+			select {
+			case <-p.shutdownCh:
+				return
+			case <-p.journalCh:
+				if err := p.journal.rotate(p.index.local()); err != nil {
+					p.logger.Error("journal rotation failed", "err", err)
+				}
+			}
+		}
+	}()
+}
+
 // Start runs the pool's main loop in the background.
 // On each request received, the appropriate handler
 // is invoked in a separate goroutine.
@@ -338,6 +385,9 @@ func (p *TxPool) Start() {
 
 	// start gossip batchers
 	p.startGossipBatchers()
+
+	// start journal
+	p.startJournal()
 
 	//	run the handler for high gauge level pruning
 	go func() {
@@ -372,6 +422,7 @@ func (p *TxPool) Start() {
 func (p *TxPool) Close() {
 	p.eventManager.Close()
 	close(p.shutdownCh)
+	p.journal.close()
 	p.stopGossipBatchers() // wait for gossip flush
 }
 
@@ -391,6 +442,12 @@ func (p *TxPool) SetSealing(sealing bool) {
 func (p *TxPool) AddTx(tx *types.Transaction) error {
 	if err := p.addTx(local, tx); err != nil {
 		p.logger.Error("failed to add tx", "err", err)
+
+		return err
+	}
+
+	if err := p.journal.insert(tx); err != nil {
+		p.logger.Error("failed to insert tx into journal", "err", err)
 
 		return err
 	}
@@ -882,6 +939,11 @@ func (p *TxPool) pruneAccountsWithNonceHoles() {
 func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 	if p.logger.IsTrace() {
 		p.logger.Trace("add tx", "origin", origin.String(), "hash", tx.Hash().String(), "type", tx.Type())
+	}
+
+	// check if local tx
+	if origin == local {
+		tx.IsLocal = true
 	}
 
 	// validate incoming tx

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -941,10 +941,8 @@ func (p *TxPool) addTx(origin txOrigin, tx *types.Transaction) error {
 		p.logger.Trace("add tx", "origin", origin.String(), "hash", tx.Hash().String(), "type", tx.Type())
 	}
 
-	// check if local tx
-	if origin == local {
-		tx.IsLocal = true
-	}
+	// set IsLocal
+	tx.IsLocal = origin == local
 
 	// validate incoming tx
 	if err := p.validateTx(tx); err != nil {

--- a/txpool/txpool_test.go
+++ b/txpool/txpool_test.go
@@ -355,7 +355,7 @@ func TestAddTxErrors(t *testing.T) {
 		tx = signTx(tx)
 
 		// enqueue tx
-		assert.NoError(t, pool.AddTx(tx))
+		assert.NoError(t, pool.addTx(local, tx))
 
 		_, exists := pool.index.get(tx.Hash())
 		assert.True(t, exists)

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -64,6 +64,9 @@ type Transaction struct {
 
 	// Cache
 	size atomic.Pointer[uint64]
+
+	// IsLocal
+	IsLocal bool
 }
 
 type Transactions []*Transaction


### PR DESCRIPTION
# Description

In order to prevent local transactions to be lost when node restarts a txpool journal is introduced. It is a textual file which keeps local transactions in the rlp format. When node starts it loads local transactions from the journal into the pool. Each new local transaction received through JSON RPC is inserted into the journal. Journal is recreated immediately after loading on node start or on each 1000 new local transactions. We can change this number later or make it configurable if needed.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually