### PR TITLE
Journal rotate size

### DIFF
--- a/.github/workflows/deploy-network.yml
+++ b/.github/workflows/deploy-network.yml
@@ -204,6 +204,7 @@ jobs:
           sed 's/is_london_fork_active: .*/is_london_fork_active: ${{ inputs.is_london_fork_active }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/gossip_msg_size: .*/gossip_msg_size: ${{ inputs.gossip_msg_size }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/tx_gossip_batch_size: .*/tx_gossip_batch_size: 10000/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
+          sed 's/journal_rotate_size: .*/journal_rotate_size: 10000/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/jsonrpc_batch_request_limit: .*/jsonrpc_batch_request_limit: 0/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/log_level: .*/log_level: ${{ vars.LOG_LEVEL }}/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml
           sed 's/epoch_reward: .*/epoch_reward: 1000000000/g' group_vars/all.yml > group_vars/all.yml.tmp && mv group_vars/all.yml.tmp group_vars/all.yml

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -71,6 +71,7 @@ type TxPool struct {
 	MaxSlots           uint64 `json:"max_slots" yaml:"max_slots"`
 	MaxAccountEnqueued uint64 `json:"max_account_enqueued" yaml:"max_account_enqueued"`
 	TxGossipBatchSize  uint64 `json:"tx_gossip_batch_size" yaml:"tx_gossip_batch_size"`
+	JournalRotateSize  uint64 `json:"journal_rotate_size" yaml:"journal_rotate_size"`
 }
 
 // Headers defines the HTTP response headers required to enable CORS.
@@ -146,6 +147,7 @@ func DefaultConfig() *Config {
 			MaxSlots:           4096,
 			MaxAccountEnqueued: 128,
 			TxGossipBatchSize:  1,
+			JournalRotateSize:  1000,
 		},
 		LogLevel:    "INFO",
 		RestoreFile: "",

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -43,6 +43,7 @@ const (
 	dbEngineFlag                 = "db-engine"
 	gossipMessageSizeFlag        = "gossip-msg-size"
 	txGossipBatchSizeFlag        = "tx-gossip-batch-size"
+	journalRotateSizeFlag        = "journal-rotate-size"
 
 	relayerFlag = "relayer"
 
@@ -186,6 +187,7 @@ func (p *serverParams) generateConfig() *server.Config {
 		MaxSlots:           p.rawConfig.TxPool.MaxSlots,
 		MaxAccountEnqueued: p.rawConfig.TxPool.MaxAccountEnqueued,
 		TxGossipBatchSize:  p.rawConfig.TxPool.TxGossipBatchSize,
+		JournalRotateSize:  p.rawConfig.TxPool.JournalRotateSize,
 		SecretsManager:     p.secretsConfig,
 		RestoreFile:        p.getRestoreFilePath(),
 		LogLevel:           hclog.LevelFromString(p.rawConfig.LogLevel),

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -200,6 +200,13 @@ func setFlags(cmd *cobra.Command) {
 		"maximum number of transactions in gossip message",
 	)
 
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.TxPool.JournalRotateSize,
+		journalRotateSizeFlag,
+		defaultConfig.TxPool.JournalRotateSize,
+		"number of local transactions in journal when rotate will be executed",
+	)
+
 	cmd.Flags().StringArrayVar(
 		&params.rawConfig.CorsAllowedOrigins,
 		corsOriginFlag,

--- a/server/config.go
+++ b/server/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	MaxAccountEnqueued uint64
 	MaxSlots           uint64
 	TxGossipBatchSize  uint64
+	JournalRotateSize  uint64
 
 	Telemetry *Telemetry
 	Network   *network.Config

--- a/server/server.go
+++ b/server/server.go
@@ -383,6 +383,7 @@ func NewServer(config *Config) (*Server, error) {
 				PriceLimit:         m.config.PriceLimit,
 				MaxAccountEnqueued: m.config.MaxAccountEnqueued,
 				TxGossipBatchSize:  m.config.TxGossipBatchSize,
+				JournalRotateSize:  m.config.JournalRotateSize,
 				DataDir:            m.config.DataDir,
 				ChainID:            big.NewInt(m.config.Chain.Params.ChainID),
 				PeerID:             m.network.AddrInfo().ID,

--- a/txpool/journal.go
+++ b/txpool/journal.go
@@ -11,9 +11,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// number of txs in journal when rotate will be executed
-const journalRotate = 1000
-
 // devNull is a WriteCloser that just discards anything written into it. Its
 // goal is to allow the transaction journal to write into a fake journal when
 // loading transactions on startup without printing warnings due to no file
@@ -29,18 +26,21 @@ type journal struct {
 	path   string         // filesystem path to store the transactions at
 	writer io.WriteCloser // output stream to write new transactions into
 	logger hclog.Logger   // logger
-	count  uint32         // number of txs in journal
+	count  uint64         // number of txs in journal
 	lock   sync.Mutex     // used for journal locking during rotation
 
 	journalCh chan struct{} // used for sending journal rotation events to txpool
+
+	rotateSize uint64 // number of local txs in journal when rotate will be executed
 }
 
 // newTxJournal creates a new transaction journal to
-func newTxJournal(path string, logger hclog.Logger, journalCh chan struct{}) *journal {
+func newTxJournal(path string, logger hclog.Logger, journalCh chan struct{}, rotateSize uint64) *journal {
 	return &journal{
-		path:      path,
-		logger:    logger,
-		journalCh: journalCh,
+		path:       path,
+		logger:     logger,
+		journalCh:  journalCh,
+		rotateSize: rotateSize,
 	}
 }
 
@@ -99,7 +99,7 @@ func (j *journal) insert(tx *types.Transaction) error {
 	_, err := j.writer.Write(tx.MarshalRLP())
 	if err == nil {
 		j.count++
-		if j.count == journalRotate {
+		if j.count == j.rotateSize {
 			// send event
 			j.journalCh <- struct{}{}
 		}

--- a/txpool/journal_test.go
+++ b/txpool/journal_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const journalRotate = 1000
+
 func TestJournalLoad(t *testing.T) {
 	t.Parallel()
 
@@ -68,7 +70,7 @@ func TestJournalLoad(t *testing.T) {
 	}
 
 	// init journal
-	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), make(chan struct{}))
+	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), make(chan struct{}), journalRotate)
 
 	// add txs into journal with rotate
 	require.NoError(t, journal.rotate(originalTxs))
@@ -106,7 +108,7 @@ func TestJournalRotate(t *testing.T) {
 
 	// create journal
 	rotateCh := make(chan struct{})
-	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), rotateCh)
+	journal := newTxJournal(filepath.Join(path, "test.rlp"), hclog.NewNullLogger(), rotateCh, journalRotate)
 
 	// init journal
 	require.NoError(t, journal.rotate([]*types.Transaction{}))

--- a/txpool/txpool.go
+++ b/txpool/txpool.go
@@ -104,6 +104,7 @@ type Config struct {
 	MaxSlots           uint64
 	MaxAccountEnqueued uint64
 	TxGossipBatchSize  uint64
+	JournalRotateSize  uint64
 	ChainID            *big.Int
 	PeerID             peer.ID
 	DataDir            string
@@ -210,6 +211,9 @@ type TxPool struct {
 	// journal channel
 	journalCh chan struct{}
 
+	// number of local txs in journal when rotate will be executed
+	journalRotateSize uint64
+
 	// data dir
 	dataDir string
 }
@@ -238,6 +242,7 @@ func NewTxPool(
 		localPeerID:       config.PeerID,
 		dataDir:           config.DataDir,
 		txGossipBatchSize: int(config.TxGossipBatchSize),
+		journalRotateSize: config.JournalRotateSize,
 
 		//	main loop channels
 		promoteReqCh: make(chan promoteRequest),
@@ -349,7 +354,8 @@ func (p *TxPool) startJournal() {
 		p.logger.Error("txpool journal directory setup failed", "err", err)
 	}
 
-	p.journal = newTxJournal(filepath.Join(p.dataDir, journalDir, "transactions.rlp"), p.logger, p.journalCh)
+	p.journal = newTxJournal(filepath.Join(p.dataDir, journalDir, "transactions.rlp"),
+		p.logger, p.journalCh, p.journalRotateSize)
 
 	if err := p.journal.load(func(tx *types.Transaction) error {
 		return p.AddTx(tx)


### PR DESCRIPTION
# Description

journal-rotate-size flag introduced in order to override default journal-rotate-size which is 1000, when needed.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually

### Manual tests

EOA load test with deployed network and journal-rotate-size set to 10000