### PR TITLE
feat: tear down process with unfunding vus

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Start Load Test
         id: load_test_results
         run: |
-          ./blade load-test --jsonrpc "http://${{ needs.check_network.outputs.rpc_url }}" --mnemonic "${{ secrets.AWS_LOADTESTRUNNER_MNEMONIC }}" --name "results" --type ${{ inputs.type }} ${{ inputs.dynamic == true && '--dynamic' || '' }} --vus ${{ inputs.vus }} --txs-per-user ${{ inputs.txs_per_user }} --batch-size ${{ inputs.batch_size }} --txpool-timeout ${{ inputs.txpool_timeout }} ${{ inputs.wait_txpool == true && '--wait-txpool' || '' }} --receipts-timeout ${{ inputs.receipts_timeout }} --to-json ${{ inputs.environment == 'testnet' && '--tear-down' }}
+          ./blade load-test --jsonrpc "http://${{ needs.check_network.outputs.rpc_url }}" --mnemonic "${{ secrets.AWS_LOADTESTRUNNER_MNEMONIC }}" --name "results" --type ${{ inputs.type }} ${{ inputs.dynamic == true && '--dynamic' || '' }} --vus ${{ inputs.vus }} --txs-per-user ${{ inputs.txs_per_user }} --batch-size ${{ inputs.batch_size }} --txpool-timeout ${{ inputs.txpool_timeout }} ${{ inputs.wait_txpool == true && '--wait-txpool' || '' }} --receipts-timeout ${{ inputs.receipts_timeout }} --to-json ${{ inputs.environment == 'testnet' && '--tear-down' || ''}}
           echo "total_time=$(cat results_${{ inputs.type }}.json | jq -r '.totalTime')" >> $GITHUB_OUTPUT
           echo "total_txs=$(cat results_${{ inputs.type }}.json | jq -r '.totalTxs')" >> $GITHUB_OUTPUT
           echo "total_blocks=$(cat results_${{ inputs.type }}.json | jq -r '.totalBlocks')" >> $GITHUB_OUTPUT

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Start Load Test
         id: load_test_results
         run: |
-          ./blade load-test --jsonrpc "http://${{ needs.check_network.outputs.rpc_url }}" --mnemonic "${{ secrets.AWS_LOADTESTRUNNER_MNEMONIC }}" --name "results" --type ${{ inputs.type }} ${{ inputs.dynamic == true && '--dynamic' || '' }} --vus ${{ inputs.vus }} --txs-per-user ${{ inputs.txs_per_user }} --batch-size ${{ inputs.batch_size }} --txpool-timeout ${{ inputs.txpool_timeout }} ${{ inputs.wait_txpool == true && '--wait-txpool' || '' }} --receipts-timeout ${{ inputs.receipts_timeout }} --to-json
+          ./blade load-test --jsonrpc "http://${{ needs.check_network.outputs.rpc_url }}" --mnemonic "${{ secrets.AWS_LOADTESTRUNNER_MNEMONIC }}" --name "results" --type ${{ inputs.type }} ${{ inputs.dynamic == true && '--dynamic' || '' }} --vus ${{ inputs.vus }} --txs-per-user ${{ inputs.txs_per_user }} --batch-size ${{ inputs.batch_size }} --txpool-timeout ${{ inputs.txpool_timeout }} ${{ inputs.wait_txpool == true && '--wait-txpool' || '' }} --receipts-timeout ${{ inputs.receipts_timeout }} --to-json ${{ inputs.environment == 'testnet' && '--tear-down' }}
           echo "total_time=$(cat results_${{ inputs.type }}.json | jq -r '.totalTime')" >> $GITHUB_OUTPUT
           echo "total_txs=$(cat results_${{ inputs.type }}.json | jq -r '.totalTxs')" >> $GITHUB_OUTPUT
           echo "total_blocks=$(cat results_${{ inputs.type }}.json | jq -r '.totalBlocks')" >> $GITHUB_OUTPUT

--- a/command/loadtest/load_test_run.go
+++ b/command/loadtest/load_test_run.go
@@ -152,6 +152,13 @@ func setFlags(cmd *cobra.Command) {
 		"the deadband of block numbers, that is used when checking whether all the nodes are on the same block number",
 	)
 
+	cmd.Flags().BoolVar(
+		&params.tearDown,
+		tearDownFlag,
+		false,
+		"indicates whether to tear down the load test",
+	)
+
 	_ = cmd.MarkFlagRequired(MnemonicFlag)
 	_ = cmd.MarkFlagRequired(loadTestTypeFlag)
 
@@ -182,6 +189,7 @@ func runCommand(cmd *cobra.Command, _ []string) {
 		TxPoolReadThreads:    params.txpoolReadThreads,
 		ReceiversNum:         params.receiversNum,
 		BlockNumberDeadband:  params.blockNumberDeadband,
+		TearDown:             params.tearDown,
 	})
 
 	if err != nil {

--- a/command/loadtest/params.go
+++ b/command/loadtest/params.go
@@ -33,6 +33,8 @@ const (
 	receiversNumFlag = "receivers-num"
 
 	blockNumberDeadbandFlag = "block-num-deadband"
+
+	tearDownFlag = "tear-down"
 )
 
 var (
@@ -75,6 +77,8 @@ type loadTestParams struct {
 	receiversNum int
 
 	blockNumberDeadband uint64
+
+	tearDown bool
 }
 
 func (ltp *loadTestParams) validateFlags() error {

--- a/loadtest/runner/base_load_test_runner.go
+++ b/loadtest/runner/base_load_test_runner.go
@@ -103,6 +103,107 @@ func NewBaseLoadTestRunner(cfg LoadTestConfig) (*BaseLoadTestRunner, error) {
 	}, nil
 }
 
+func (r *BaseLoadTestRunner) tearDown() error {
+	if !r.cfg.TearDown {
+		return nil
+	}
+
+	fmt.Println("=============================================================")
+	fmt.Println("Unfunding users...")
+
+	start := time.Now().UTC()
+	bar := progressbar.Default(int64(r.cfg.VUs), "Unfund users")
+
+	defer func() {
+		_ = bar.Close()
+
+		fmt.Println("Unfund users took", time.Since(start))
+	}()
+
+	txRelayer, err := txrelayer.NewTxRelayer(
+		txrelayer.WithClient(r.clients.getClient()),
+		txrelayer.WithoutNonceGet(),
+	)
+	if err != nil {
+		return err
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	loadTestAddr := r.loadTestAccount.key.Address()
+
+	chainID, err := r.clients.getClient().ChainID()
+	if err != nil {
+		return err
+	}
+
+	for _, vu := range r.vus {
+		vu := vu
+
+		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+				addr := vu.key.Address()
+
+				balance, err := r.clients.getClient().GetBalance(addr, jsonrpc.LatestBlockNumberOrHash)
+				if err != nil {
+					return err
+				}
+
+				refundAmount := balance.Sub(balance, big.NewInt(1e16))
+
+				feeData, err := getFeeData(r.clients.getClient(), false)
+				if err != nil {
+					return err
+				}
+
+				var tx *types.Transaction
+
+				if r.cfg.DynamicTxs {
+					tx = types.NewTx(types.NewDynamicFeeTx(
+						types.WithNonce(vu.nonce),
+						types.WithTo(&loadTestAddr),
+						types.WithFrom(addr),
+						types.WithGasFeeCap(feeData.gasFeeCap),
+						types.WithGasTipCap(feeData.gasTipCap),
+						types.WithChainID(chainID),
+						types.WithValue(refundAmount),
+					))
+				} else {
+					tx = types.NewTx(types.NewLegacyTx(
+						types.WithNonce(vu.nonce),
+						types.WithTo(&loadTestAddr),
+						types.WithGasPrice(feeData.gasPrice),
+						types.WithFrom(addr),
+						types.WithValue(refundAmount),
+					))
+				}
+
+				receipt, err := txRelayer.SendTransaction(tx, vu.key)
+				if err != nil {
+					return fmt.Errorf("failed to send transaction: %w", err)
+				}
+
+				if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
+					return fmt.Errorf("failed to tear down user %s", vu.key.Address().String())
+				}
+
+				_ = bar.Add(1)
+
+				return nil
+			}
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *BaseLoadTestRunner) printStateDBMetrics() {
 	fmt.Println("=============================================================")
 	fmt.Println("Getting state DB metrics...")

--- a/loadtest/runner/eoa_runner.go
+++ b/loadtest/runner/eoa_runner.go
@@ -99,6 +99,10 @@ func (e *EOARunner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := e.tearDown(); err != nil {
+		return err
+	}
+
 	return e.printNodeInfos(nodeInfos)
 }
 

--- a/loadtest/runner/erc20_runner.go
+++ b/loadtest/runner/erc20_runner.go
@@ -119,6 +119,10 @@ func (e *ERC20Runner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := e.tearDown(); err != nil {
+		return err
+	}
+
 	return e.printNodeInfos(nodeInfos)
 }
 

--- a/loadtest/runner/erc721_runner.go
+++ b/loadtest/runner/erc721_runner.go
@@ -113,6 +113,10 @@ func (e *ERC721Runner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := e.tearDown(); err != nil {
+		return err
+	}
+
 	return e.printNodeInfos(nodeInfos)
 }
 

--- a/loadtest/runner/load_test_runner.go
+++ b/loadtest/runner/load_test_runner.go
@@ -77,6 +77,9 @@ type LoadTestConfig struct {
 
 	// BlockNumberDeadband is the maximum allowed discrepancy in the latest block numbers among the nodes
 	BlockNumberDeadband uint64
+
+	// Tear down for the load test
+	TearDown bool // TearDown indicates whether to tear down the load test.
 }
 
 // LoadTestRunner represents a runner for load tests.

--- a/loadtest/runner/mixed_tx_runner.go
+++ b/loadtest/runner/mixed_tx_runner.go
@@ -138,6 +138,10 @@ func (m *MixedTxRunner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := m.tearDown(); err != nil {
+		return err
+	}
+
 	return m.printNodeInfos(nodeInfos)
 }
 

--- a/loadtest/runner/perf_contract_runner.go
+++ b/loadtest/runner/perf_contract_runner.go
@@ -210,6 +210,10 @@ func (p *PerfContractRunner) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := p.tearDown(); err != nil {
+		return err
+	}
+
 	return p.printNodeInfos(nodeInfos)
 }
 


### PR DESCRIPTION
# Description

This PR introduces tear down from Load Tests when using flag `--tear-down`.
Tear down process returns funds from Virtual Users to Load Test Account (unfunds them).

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
