### PR TITLE
Add mechanism for restoring unexecuted and retry lists

### DIFF
--- a/consensus/polybft/bridge/bridge.go
+++ b/consensus/polybft/bridge/bridge.go
@@ -121,7 +121,7 @@ func NewBridge(runtime Runtime,
 			topic:             bridgeTopic,
 			key:               runtimeConfig.Key,
 			maxNumberOfEvents: maxNumberOfBatchEvents,
-		}, runtime, relayer.Client(), externalChainID, internalChainID, blockchain)
+		}, runtime, relayer.Client(), externalChainID, internalChainID, blockchain, dbTx)
 		bridge.bridgeManagers[externalChainID] = bridgeManager
 
 		if err := bridgeManager.Start(runtimeConfig); err != nil {

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -1118,9 +1118,11 @@ func (b *bridgeEventManager) ProcessLog(
 				sid.Uint64(),
 				did.Uint64()))
 
-		err = b.state.insertUnexecutedBatch(b.externalChainID, baseHash, event.ID, dbTx)
-		if err != nil {
-			b.logger.Error("could not insert unexecuted batch", "err", err)
+		if sid.Uint64() == b.internalChainID {
+			err = b.state.insertUnexecutedBatch(b.externalChainID, baseHash, event.ID, dbTx)
+			if err != nil {
+				b.logger.Error("could not insert unexecuted batch", "err", err)
+			}
 		}
 
 	default:

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -741,15 +741,9 @@ func (b *bridgeEventManager) handleRetry(
 	// the current (i).
 	for i := 0; i < len(b.unexecutedBatches); {
 		// For each batch in the list, we check whether the number of the last processed block
-		// on the external chain is greater than (equals to) the batch threshold. If so, batch
-		// is ready for retry.
-		//
-		// Note: for a batch to be considered invalid on the external chain (external Gateway),
-		// the current chain block number must be greater than the batch threshold. However, as
-		// `blockNumber` represents the last PROCESSED block, we can use `>=` instead of `>` (as
-		// on the external Gateway SC). This is because if the threshold block has already been
-		// processed and the batch still remains in the list, it is ready for the retry.
-		if blockNumber >= b.unexecutedBatches[i].Threshold.Uint64() {
+		// on the external chain is greater than the batch threshold. If so, batch is ready for
+		// retry.
+		if blockNumber > b.unexecutedBatches[i].Threshold.Uint64() {
 			retryBatch := *b.unexecutedBatches[i]
 			retryBatch.Threshold = big.NewInt(0)
 			retryBatch.CommitCounter = big.NewInt(0)

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -59,6 +59,10 @@ type JSONRPCClient interface {
 	GetBlockByNumber(jsonrpc.BlockNumber, bool) (*types.Block, error)
 }
 
+type ChainTipProvider interface {
+	GetLastProcessedBlock() (uint64, error)
+}
+
 // BridgeManager is an interface that defines functions for bridge workflow
 type BridgeManager interface {
 	state.EventSubscriber
@@ -132,9 +136,9 @@ type bridgeEventManager struct {
 	internalChainID         uint64
 	blockchain              polychain.Blockchain
 
-	runtime                   Runtime
-	tracker                   *tracker.EventTracker
-	externalConfirmationDepth *big.Int
+	runtime             Runtime
+	tracker             *tracker.EventTracker
+	externalTipProvider ChainTipProvider
 }
 
 // newBridgeManager creates a new instance of bridge event manager
@@ -144,8 +148,8 @@ func newBridgeManager(
 	config *bridgeEventManagerConfig,
 	runtime Runtime,
 	externalClient JSONRPCClient,
-	externalChainID, internalChainID uint64, blockchain polychain.Blockchain) *bridgeEventManager {
-	return &bridgeEventManager{
+	externalChainID, internalChainID uint64, blockchain polychain.Blockchain, dbTx *bolt.Tx) *bridgeEventManager {
+	bm := &bridgeEventManager{
 		logger:              logger,
 		state:               state,
 		config:              config,
@@ -156,6 +160,46 @@ func newBridgeManager(
 		externalChainID:     externalChainID,
 		internalChainID:     internalChainID,
 		blockchain:          blockchain,
+	}
+
+	bm.restoreUnexecutedBatches(dbTx)
+
+	return bm
+}
+
+// restoreUnexecutedBatches restores unexecuted batches (and indirectly retry batches).
+func (b *bridgeEventManager) restoreUnexecutedBatches(dbTx *bolt.Tx) {
+	ids, err := b.state.getUnexecutedBatches(b.externalChainID, dbTx)
+	if err != nil {
+		b.logger.Error("could not get unexecuted batches", "err", err)
+
+		return
+	}
+
+	if len(ids) == 0 {
+		return
+	}
+
+	provider, err := b.blockchain.GetStateProviderForBlock(b.blockchain.CurrentHeader())
+	if err != nil {
+		b.logger.Error("could not get state provider", "err", err)
+
+		return
+	}
+
+	ss := b.blockchain.GetSystemState(provider)
+	for _, ID := range ids {
+		batch, err := ss.GetBridgeBatchByNumber(big.NewInt(int64(ID)))
+		if err != nil {
+			b.logger.Error("could not get bridge batch", "err", err)
+
+			continue
+		}
+
+		// Since the batch has already been voted on, the specific epoch doesn't matter.
+		b.unexecutedBatches = append(b.unexecutedBatches, &PendingBridgeBatch{
+			BridgeMessageBatch: batch.Batch,
+		})
 	}
 }
 
@@ -171,7 +215,6 @@ func (b *bridgeEventManager) Start(runtimeConfig *config.Runtime) error {
 	}
 
 	b.tracker = tracker
-	b.externalConfirmationDepth = big.NewInt(int64(runtimeConfig.EventTracker.NumBlockConfirmations))
 
 	return nil
 }
@@ -192,6 +235,8 @@ func (b *bridgeEventManager) initTracker(runtimeCfg *config.Runtime) (*tracker.E
 	if err != nil {
 		return nil, err
 	}
+
+	b.externalTipProvider = store
 
 	eventTracker, err := tracker.NewEventTracker(
 		&tracker.EventTrackerConfig{
@@ -679,15 +724,13 @@ func (b *bridgeEventManager) buildBridgeBatch(
 func (b *bridgeEventManager) handleRetry(
 	sysState systemstate.SystemState,
 	dbTx *bolt.Tx) {
-	block, err := b.externalClient.GetBlockByNumber(jsonrpc.BlockNumber(ethgo.Latest), false)
+	blockNumber, err := b.externalTipProvider.GetLastProcessedBlock()
 	if err != nil {
 		// Log the error, but won't return because it might be just a temporary problem.
 		b.logger.Error("could not poll the block from the external chain", "err", err)
 
 		return
 	}
-
-	blockNumber := big.NewInt(int64(block.Header.Number))
 
 	b.lock.Lock()
 
@@ -697,15 +740,16 @@ func (b *bridgeEventManager) handleRetry(
 	// is successfully created, as the unexecuted list shrinks by one, making the next batch (i+1)
 	// the current (i).
 	for i := 0; i < len(b.unexecutedBatches); {
-		rt := big.NewInt(0).Add(b.unexecutedBatches[i].Threshold, b.externalConfirmationDepth)
-
-		// We add a random small number (salt) for extra security. This is not required.
-		rt.Add(rt, big.NewInt(2))
-
-		// For each batch from the unexecuted list, we check whether the number of the current
-		// block on the external chain is greater than (equal to) the batch threshold (including
-		// salt and potential reorganization). If so, batch is ready for retry.
-		if blockNumber.Cmp(rt) >= 0 {
+		// For each batch in the list, we check whether the number of the last processed block
+		// on the external chain is greater than (equals to) the batch threshold. If so, batch
+		// is ready for retry.
+		//
+		// Note: for a batch to be considered invalid on the external chain (external Gateway),
+		// the current chain block number must be greater than the batch threshold. However, as
+		// `blockNumber` represents the last PROCESSED block, we can use `>=` instead of `>` (as
+		// on the external Gateway SC). This is because if the threshold block has already been
+		// processed and the batch still remains in the list, it is ready for the retry.
+		if blockNumber >= b.unexecutedBatches[i].Threshold.Uint64() {
 			retryBatch := *b.unexecutedBatches[i]
 			retryBatch.Threshold = big.NewInt(0)
 			retryBatch.CommitCounter = big.NewInt(0)
@@ -758,7 +802,7 @@ func (b *bridgeEventManager) handleRetry(
 
 	// Creating a new retry candidate for each batch that is ready for the retry.
 	for hash := range b.retryBatches {
-		err = b.buildRetryBridgeBatch(hash, blockNumber.Uint64(), dbTx)
+		err = b.buildRetryBridgeBatch(hash, blockNumber, dbTx)
 		if err != nil {
 			b.logger.Error("could not create retry bridge batch", "err", err)
 		}
@@ -1074,6 +1118,11 @@ func (b *bridgeEventManager) ProcessLog(
 				sid.Uint64(),
 				did.Uint64()))
 
+		err = b.state.insertUnexecutedBatch(b.externalChainID, baseHash, event.ID, dbTx)
+		if err != nil {
+			b.logger.Error("could not insert unexecuted batch", "err", err)
+		}
+
 	default:
 		b.logger.Error("unknown bridge event")
 
@@ -1276,6 +1325,18 @@ func (b *bridgeEventManager) AddLog(
 				continue
 			}
 
+			b.unexecutedBatches[i].Threshold = big.NewInt(0)
+			b.unexecutedBatches[i].CommitCounter = big.NewInt(0)
+
+			baseHash, err := b.unexecutedBatches[i].Hash()
+			if err != nil {
+				b.logger.Error("could not calculate a base hash for the bridge batch", "err", err)
+
+				i++
+
+				continue
+			}
+
 			b.logger.Info(
 				fmt.Sprintf("Batch (0x%s, %d -> %d)"+
 					"has been successfully removed from the unexecuted list",
@@ -1284,6 +1345,11 @@ func (b *bridgeEventManager) AddLog(
 					b.unexecutedBatches[i].DestinationChainID.Uint64()))
 
 			b.unexecutedBatches = append(b.unexecutedBatches[:i], b.unexecutedBatches[i+1:]...)
+
+			err = b.state.removeUnexecutedBatch(b.externalChainID, baseHash, dbTx)
+			if err != nil {
+				b.logger.Error("could not insert unexecuted batch", "err", err)
+			}
 		}
 
 	default:

--- a/consensus/polybft/bridge/bridge_manager_test.go
+++ b/consensus/polybft/bridge/bridge_manager_test.go
@@ -26,7 +26,6 @@ import (
 	systemstate "github.com/0xPolygon/polygon-edge/consensus/polybft/system_state"
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/validator"
 	"github.com/0xPolygon/polygon-edge/helper/common"
-	"github.com/0xPolygon/polygon-edge/jsonrpc"
 	"github.com/0xPolygon/polygon-edge/types"
 )
 
@@ -68,7 +67,7 @@ func newTestState(t *testing.T) *BridgeManagerStore {
 	return store
 }
 
-func newTestBridgeManager(t *testing.T, key *validator.TestValidator, runtime Runtime, jsonClient JSONRPCClient, blockchain blockchain.Blockchain) *bridgeEventManager {
+func newTestBridgeManager(t *testing.T, key *validator.TestValidator, runtime Runtime, tipProvider ChainTipProvider, blockchain blockchain.Blockchain) *bridgeEventManager {
 	t.Helper()
 
 	state := newTestState(t)
@@ -84,11 +83,11 @@ func newTestBridgeManager(t *testing.T, key *validator.TestValidator, runtime Ru
 			topic:             topic,
 			key:               key.Key(),
 			maxNumberOfEvents: maxNumberOfBatchEvents,
-		}, runtime, jsonClient, 1, 100, blockchain)
+		}, runtime, nil, 1, 100, blockchain, nil)
 
 	s.nextEventIDE2I = 1
 	s.nextEventIDI2E = 1
-	s.externalConfirmationDepth = big.NewInt(5)
+	s.externalTipProvider = tipProvider
 
 	return s
 }
@@ -395,6 +394,157 @@ func TestBridgeEventManager_RemoveProcessedEvents(t *testing.T) {
 	stateSyncEventsAfter, err := s.state.list(s.internalChainID)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(stateSyncEventsAfter))
+}
+
+func Test_restore_Unexecuted_and_Retry_Batches(t *testing.T) {
+	vals := validator.NewTestValidators(t, 5)
+
+	// The purpose of this test is to verify the correctness of restoring the unexecuted/retry
+	// list/maps. The test involves two batches, where one has exceeded its threshold while the
+	// other has not. When the restoreUnexecutedBatches method is called, both batches should
+	// be restored (i.e. added to the unexecuted list). Later, when the handleRetry method is
+	// invoked, the batch with the expired threshold should be moved to the retry maps.
+
+	bc := &blockchain.BlockchainMock{}
+	ss := &systemstate.SystemStateMock{}
+	tp := &mockChainTipProvider{}
+
+	msg1 := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(1),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+	}
+
+	msg2 := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(2),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+	}
+
+	msg3 := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(3),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+	}
+
+	bmb1 := &contractsapi.BridgeMessageBatch{
+		Messages:           []*contractsapi.BridgeMessage{msg1, msg2},
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		Threshold:          big.NewInt(100),
+		CommitCounter:      big.NewInt(1),
+	}
+
+	bmb2 := &contractsapi.BridgeMessageBatch{
+		Messages:           []*contractsapi.BridgeMessage{msg3},
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		Threshold:          big.NewInt(150),
+		CommitCounter:      big.NewInt(1),
+	}
+
+	bc.On("GetStateProviderForBlock", mock.Anything).Return(nil)
+	bc.On("CurrentHeader", mock.Anything).Return(&types.Header{})
+	bc.On("GetSystemState", mock.Anything).Return(ss)
+	ss.On("GetBridgeBatchByNumber", big.NewInt(20)).Return(
+		&contractsapi.SignedBridgeMessageBatch{Batch: bmb1})
+	ss.On("GetBridgeBatchByNumber", big.NewInt(30)).Return(
+		&contractsapi.SignedBridgeMessageBatch{Batch: bmb2})
+	ss.On("GetBatchCommitCounter", mock.Anything).Return(big.NewInt(2))
+	tp.On("GetLastProcessedBlock", mock.Anything).Return(uint64(120))
+
+	bm := newTestBridgeManager(t,
+		vals.GetValidator("0"),
+		&mockRuntime{isActiveValidator: false},
+		tp,
+		bc,
+	)
+
+	pbb1 := PendingBridgeBatch{
+		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{
+			Messages:           []*contractsapi.BridgeMessage{msg1, msg2},
+			SourceChainID:      big.NewInt(100),
+			DestinationChainID: big.NewInt(1),
+			Threshold:          big.NewInt(0),
+			CommitCounter:      big.NewInt(0),
+		},
+	}
+
+	baseHash1, err := pbb1.Hash()
+	require.NoError(t, err)
+
+	pbb1.BridgeMessageBatch = bmb1
+
+	fullHash1, err := pbb1.Hash()
+	require.NoError(t, err)
+
+	err = bm.state.insertUnexecutedBatch(1, baseHash1, big.NewInt(20), nil)
+	require.NoError(t, err)
+
+	require.Nil(t, bm.unexecutedBatches)
+
+	pbb2 := PendingBridgeBatch{
+		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{
+			Messages:           []*contractsapi.BridgeMessage{msg3},
+			SourceChainID:      big.NewInt(100),
+			DestinationChainID: big.NewInt(1),
+			Threshold:          big.NewInt(0),
+			CommitCounter:      big.NewInt(0),
+		},
+	}
+
+	baseHash2, err := pbb2.Hash()
+	require.NoError(t, err)
+
+	pbb2.BridgeMessageBatch = bmb2
+
+	fullHash2, err := pbb2.Hash()
+	require.NoError(t, err)
+
+	err = bm.state.insertUnexecutedBatch(1, baseHash2, big.NewInt(30), nil)
+	require.NoError(t, err)
+
+	require.Nil(t, bm.unexecutedBatches)
+
+	bm.restoreUnexecutedBatches(nil)
+
+	require.EqualValues(t, 2, len(bm.unexecutedBatches))
+	require.EqualValues(t, 0, len(bm.retryBatches))
+	require.EqualValues(t, 0, len(bm.pendingRetryBatches))
+
+	presentHash1, err := bm.unexecutedBatches[0].Hash()
+	require.NoError(t, err)
+
+	presentHash2, err := bm.unexecutedBatches[1].Hash()
+	require.NoError(t, err)
+
+	presentHashes := []types.Hash{presentHash1, presentHash2}
+
+	require.Contains(t, presentHashes, fullHash1)
+	require.Contains(t, presentHashes, fullHash2)
+
+	bm.handleRetry(ss, nil)
+
+	require.EqualValues(t, 1, len(bm.unexecutedBatches))
+	require.EqualValues(t, 1, len(bm.retryBatches))
+	require.EqualValues(t, 1, len(bm.pendingRetryBatches))
+
+	presentHash, err := bm.unexecutedBatches[0].Hash()
+	require.NoError(t, err)
+
+	require.EqualValues(t, fullHash2, presentHash)
+
+	_, ok := bm.retryBatches[baseHash1]
+	require.True(t, ok)
+
+	_, ok = bm.pendingRetryBatches[baseHash1]
+	require.True(t, ok)
+
+	_, ok = bm.retryBatches[baseHash2]
+	require.False(t, ok)
+
+	_, ok = bm.pendingRetryBatches[baseHash2]
+	require.False(t, ok)
 }
 
 func Test_handleBridgeMessageEvent(t *testing.T) {
@@ -2231,18 +2381,14 @@ func Test_handleRetry(t *testing.T) {
 
 	// Expected: the batch should not go into retry, as its threshold has not yet "expired".
 	t.Run("1", func(t *testing.T) {
-		client := &mockJSONRPCClient{}
+		tipProvider := &mockChainTipProvider{}
 
-		client.On("GetBlockByNumber", mock.Anything).Return(&types.Block{
-			Header: &types.Header{
-				Number: 100,
-			},
-		})
+		tipProvider.On("GetLastProcessedBlock", mock.Anything).Return(uint64(100), nil)
 
 		bm := newTestBridgeManager(t,
 			vals.GetValidator("0"),
 			&mockRuntime{isActiveValidator: false},
-			client,
+			tipProvider,
 			nil,
 		)
 
@@ -2263,23 +2409,18 @@ func Test_handleRetry(t *testing.T) {
 	})
 
 	// This test illustrates a scenario where the batch being checked has its threshold set at
-	// block 120, while the current block on the external chain is at 128.
+	// block 120, while the current block on the external chain is at 121.
 
-	// Expected: the batch should go into retry, as its threshold has "expired" (120 + 5 + 2 is
-	// smaller than 128).
+	// Expected: the batch should go into retry, as its threshold has "expired" (120 < 121).
 	t.Run("2", func(t *testing.T) {
-		client := &mockJSONRPCClient{}
+		tipProvider := &mockChainTipProvider{}
 
-		client.On("GetBlockByNumber", mock.Anything).Return(&types.Block{
-			Header: &types.Header{
-				Number: 128,
-			},
-		})
+		tipProvider.On("GetLastProcessedBlock", mock.Anything).Return(uint64(121), nil)
 
 		bm := newTestBridgeManager(t,
 			vals.GetValidator("0"),
 			&mockRuntime{isActiveValidator: false},
-			client,
+			tipProvider,
 			nil,
 		)
 
@@ -2513,14 +2654,14 @@ func (m *mockRuntime) IsActiveValidator() bool {
 	return m.isActiveValidator
 }
 
-type mockJSONRPCClient struct {
+type mockChainTipProvider struct {
 	mock.Mock
 }
 
-func (m *mockJSONRPCClient) GetBlockByNumber(num jsonrpc.BlockNumber, full bool) (*types.Block, error) {
-	block, _ := m.Called(num)[0].(*types.Block)
+func (m *mockChainTipProvider) GetLastProcessedBlock() (uint64, error) {
+	blockNumber, _ := m.Called()[0].(uint64)
 
-	return block, nil
+	return blockNumber, nil
 }
 
 var _ BridgeManager = (*mockBridgeManager)(nil)

--- a/consensus/polybft/bridge/state_store_bridge_message.go
+++ b/consensus/polybft/bridge/state_store_bridge_message.go
@@ -9,6 +9,7 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	systemstate "github.com/0xPolygon/polygon-edge/consensus/polybft/system_state"
 	"github.com/0xPolygon/polygon-edge/helper/common"
+	"github.com/0xPolygon/polygon-edge/types"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -21,6 +22,8 @@ var (
 	messageVotesBucket = []byte("votes")
 	// bucket to store epochs and all its nested buckets (message votes and message pool events)
 	epochsBucket = []byte("epochs")
+
+	unexecutedBatches = []byte("unexecuted")
 
 	ordinaryMessages = []byte("ordinary")
 	rollbackMessages = []byte("rollback")
@@ -67,7 +70,12 @@ func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint6
 	store := &BridgeManagerStore{db: db, chainIDs: externalChainsIDs, internalChainID: internalChainID}
 
 	initFn := func(tx *bolt.Tx) error {
-		var bridgeMessageBucket, bridgeBatchesBucket, epochBucket *bolt.Bucket
+		var (
+			bridgeMessageBucket     *bolt.Bucket
+			bridgeBatchesBucket     *bolt.Bucket
+			epochBucket             *bolt.Bucket
+			unexecutedBatchesBucket *bolt.Bucket
+		)
 
 		if bridgeMessageBucket, err = tx.CreateBucketIfNotExists(bridgeMessageEventsBucket); err != nil {
 			return fmt.Errorf("failed to create bucket=%s: %w", string(bridgeMessageEventsBucket), err)
@@ -79,6 +87,10 @@ func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint6
 
 		if epochBucket, err = tx.CreateBucketIfNotExists(epochsBucket); err != nil {
 			return fmt.Errorf("failed to create bucket=%s: %w", string(epochsBucket), err)
+		}
+
+		if unexecutedBatchesBucket, err = tx.CreateBucketIfNotExists(unexecutedBatches); err != nil {
+			return fmt.Errorf("failed to create bucket=%s: %w", string(unexecutedBatches), err)
 		}
 
 		// because we have multiple chains that can generate same events
@@ -125,6 +137,10 @@ func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint6
 			bridgeMessageChainIDBucket, err := createBucketsAndReturnBridgeMessageBucket(chainIDBytes)
 			if err != nil {
 				return err
+			}
+
+			if _, err = unexecutedBatchesBucket.CreateBucketIfNotExists(chainIDBytes); err != nil {
+				return fmt.Errorf("failed to create bucket for unexecuted batches: %w", err)
 			}
 
 			var buckets [2]*bolt.Bucket
@@ -200,7 +216,7 @@ func (bms *BridgeManagerStore) insertBridgeMessageEvent(event *contractsapi.Brid
 
 func (bms *BridgeManagerStore) removeBridgeMessageEvent(messageID, sourceChainID, destinationChainID *big.Int,
 	isRollback bool, dbTx *bolt.Tx) error {
-	insertFn := func(tx *bolt.Tx) error {
+	removeFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(messageID.Uint64())
 
 		bucket := tx.Bucket(bridgeMessageEventsBucket).
@@ -215,10 +231,10 @@ func (bms *BridgeManagerStore) removeBridgeMessageEvent(messageID, sourceChainID
 	}
 
 	if dbTx == nil {
-		return bms.db.Update(insertFn)
+		return bms.db.Update(removeFn)
 	}
 
-	return insertFn(dbTx)
+	return removeFn(dbTx)
 }
 
 func (bms *BridgeManagerStore) getBridgeMessageEvent(messageID, sourceChainID, destinationChainID *big.Int,
@@ -333,6 +349,78 @@ func (bms *BridgeManagerStore) isBridgeMessageExecuted(message *contractsapi.Bri
 	}
 
 	return executed
+}
+
+func (bms *BridgeManagerStore) getUnexecutedBatches(
+	externalChainID uint64,
+	dbTx *bolt.Tx) ([]uint64, error) {
+	var ids []uint64
+
+	getFn := func(tx *bolt.Tx) error {
+		id := common.EncodeUint64ToBytes(externalChainID)
+
+		err := tx.Bucket(unexecutedBatches).Bucket(id).ForEach(func(k, v []byte) error {
+			var id uint64
+
+			if err := json.Unmarshal(v, &id); err != nil {
+				ids = nil
+
+				return err
+			}
+
+			ids = append(ids, id)
+
+			return nil
+		})
+
+		return err
+	}
+
+	if dbTx == nil {
+		return ids, bms.db.View(getFn)
+	} else {
+		return ids, getFn(dbTx)
+	}
+}
+
+func (bms *BridgeManagerStore) insertUnexecutedBatch(
+	externalChainID uint64,
+	baseHash types.Hash,
+	batchID *big.Int,
+	dbTx *bolt.Tx) error {
+	insertFn := func(tx *bolt.Tx) error {
+		raw, err := json.Marshal(batchID)
+		if err != nil {
+			return err
+		}
+
+		return tx.Bucket(unexecutedBatches).
+			Bucket(common.EncodeUint64ToBytes(externalChainID)).
+			Put(baseHash.Bytes(), raw)
+	}
+
+	if dbTx == nil {
+		return bms.db.Update(insertFn)
+	}
+
+	return insertFn(dbTx)
+}
+
+func (bms *BridgeManagerStore) removeUnexecutedBatch(
+	externalChainID uint64,
+	baseHash types.Hash,
+	dbTx *bolt.Tx) error {
+	removeFn := func(tx *bolt.Tx) error {
+		return tx.Bucket(unexecutedBatches).
+			Bucket(common.EncodeUint64ToBytes(externalChainID)).
+			Delete(baseHash.Bytes())
+	}
+
+	if dbTx == nil {
+		return bms.db.Update(removeFn)
+	}
+
+	return removeFn(dbTx)
 }
 
 func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(result *contractsapi.BridgeMessageResultEvent,

--- a/consensus/polybft/bridge/state_store_bridge_message_test.go
+++ b/consensus/polybft/bridge/state_store_bridge_message_test.go
@@ -858,6 +858,87 @@ func Test_getBridgeMessages(t *testing.T) {
 	})
 }
 
+func Test_getUnexecutedBatches(t *testing.T) {
+	s := newTestState(t)
+
+	b1 := PendingBridgeBatch{
+		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{
+			Messages:           []*contractsapi.BridgeMessage{},
+			SourceChainID:      big.NewInt(100),
+			DestinationChainID: big.NewInt(1),
+			Threshold:          big.NewInt(0),
+			CommitCounter:      big.NewInt(0),
+		},
+	}
+
+	h1, err := b1.Hash()
+	require.NoError(t, err)
+
+	b2 := PendingBridgeBatch{
+		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{
+			Messages:           []*contractsapi.BridgeMessage{},
+			SourceChainID:      big.NewInt(100),
+			DestinationChainID: big.NewInt(1),
+			Threshold:          big.NewInt(0),
+			CommitCounter:      big.NewInt(0),
+		},
+	}
+
+	h2, err := b2.Hash()
+	require.NoError(t, err)
+
+	b3 := PendingBridgeBatch{
+		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{
+			Messages:           []*contractsapi.BridgeMessage{},
+			SourceChainID:      big.NewInt(100),
+			DestinationChainID: big.NewInt(2),
+			Threshold:          big.NewInt(1),
+			CommitCounter:      big.NewInt(400),
+		},
+	}
+
+	h3, err := b3.Hash()
+	require.NoError(t, err)
+
+	err = s.insertUnexecutedBatch(1, h1, big.NewInt(12), nil)
+	require.NoError(t, err)
+
+	ids, err := s.getUnexecutedBatches(1, nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 1, len(ids))
+	require.EqualValues(t, 12, ids[0])
+
+	err = s.insertUnexecutedBatch(1, h2, big.NewInt(24), nil)
+	require.NoError(t, err)
+
+	ids, err = s.getUnexecutedBatches(1, nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 1, len(ids))
+	require.EqualValues(t, 24, ids[0])
+
+	err = s.insertUnexecutedBatch(1, h3, big.NewInt(35), nil)
+	require.NoError(t, err)
+
+	ids, err = s.getUnexecutedBatches(1, nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 2, len(ids))
+	require.EqualValues(t, 35, ids[0])
+	require.EqualValues(t, 24, ids[1])
+
+	err = s.removeUnexecutedBatch(1, h2, nil)
+
+	require.NoError(t, err)
+
+	ids, err = s.getUnexecutedBatches(1, nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, 1, len(ids))
+	require.EqualValues(t, 35, ids[0])
+}
+
 func insertTestBridgeBatches(t *testing.T, state *BridgeManagerStore, numberOfBatches uint64) {
 	t.Helper()
 

--- a/consensus/polybft/system_state/mocks.go
+++ b/consensus/polybft/system_state/mocks.go
@@ -34,7 +34,7 @@ func (m *SystemStateMock) GetNextCommittedIndex(chainID uint64, chainType ChainT
 
 func (m *SystemStateMock) GetBridgeBatchByNumber(numberOfBatch *big.Int) (
 	*contractsapi.SignedBridgeMessageBatch, error) {
-	args := m.Called()
+	args := m.Called(numberOfBatch)
 	if len(args) == 1 {
 		batch, _ := args.Get(0).(*contractsapi.SignedBridgeMessageBatch)
 

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -42,7 +42,7 @@ import (
 func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	const (
 		validatorsCount = 4
-		transfersCount  = 5
+		transfersCount  = 1
 		epochSize       = 10
 		numberOfBridges = 1
 		bridgeAmount    = 100
@@ -237,6 +237,21 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	t.Logf("Deposited ERC20 tokens")
 
 	{
+		// wait for batch to be created
+		cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
+			latest, err := internalEndpoint.BlockNumber()
+			require.NoError(t, err)
+
+			logs, err := getFilteredLogs((&contractsapi.NewBatchEvent{}).Sig(), 0, latest, internalEndpoint)
+			require.NoError(t, err)
+
+			if len(logs) == 0 {
+				return false
+			}
+
+			return true
+		})
+
 		wg := sync.WaitGroup{}
 		wg.Add(validatorsCount)
 
@@ -254,7 +269,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 		wg.Wait()
 
 		// wait to reach threshold block
-		block := waitForBlocksOnExternal(t, threshold, externalEndpoint, 3*time.Minute)
+		block := waitForBlocksOnExternal(t, threshold+1, externalEndpoint, 3*time.Minute)
 
 		t.Logf("Reached threshold block %d", block)
 
@@ -270,6 +285,8 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 				cluster.Servers[validatorNum].Start()
 			}(i)
 		}
+
+		wg.Wait()
 	}
 
 	// start relayer

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -42,7 +45,7 @@ import (
 func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	const (
 		validatorsCount = 4
-		transfersCount  = 5
+		transfersCount  = 1
 		epochSize       = 10
 		numberOfBridges = 1
 		bridgeAmount    = 100
@@ -237,6 +240,21 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	t.Logf("Deposited ERC20 tokens")
 
 	{
+		// wait for batch to be created
+		cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
+			latest, err := internalEndpoint.BlockNumber()
+			require.NoError(t, err)
+
+			logs, err := getFilteredLogs((&contractsapi.NewBatchEvent{}).Sig(), 0, latest, internalEndpoint)
+			require.NoError(t, err)
+
+			if len(logs) == 0 {
+				return false
+			}
+
+			return true
+		})
+
 		wg := sync.WaitGroup{}
 		wg.Add(validatorsCount)
 
@@ -254,7 +272,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 		wg.Wait()
 
 		// wait to reach threshold block
-		block := waitForBlocksOnExternal(t, threshold, externalEndpoint, 3*time.Minute)
+		block := waitForBlocksOnExternal(t, threshold+1, externalEndpoint, 5*time.Minute)
 
 		t.Logf("Reached threshold block %d", block)
 
@@ -270,6 +288,8 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 				cluster.Servers[validatorNum].Start()
 			}(i)
 		}
+
+		wg.Wait()
 	}
 
 	// start relayer
@@ -332,4 +352,19 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	}
 
 	t.Logf("Test passed")
+}
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	parent := filepath.Dir(wd)
+	parent = strings.Trim(parent, "e2e-polybft")
+	wd = filepath.Join(parent, "/artifacts/blade")
+	os.Setenv("EDGE_BINARY", wd)
+	os.Setenv("E2E_TESTS", "true")
+	os.Setenv("E2E_LOGS", "true")
+	os.Setenv("E2E_LOG_LEVEL", "debug")
 }

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -238,7 +238,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 
 	{
 		// wait for batch to be created
-		cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
+		require.NoError(t, cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
 			latest, err := internalEndpoint.BlockNumber()
 			require.NoError(t, err)
 
@@ -250,7 +250,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 			}
 
 			return true
-		})
+		}))
 
 		wg := sync.WaitGroup{}
 		wg.Add(validatorsCount)

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -1,0 +1,335 @@
+package bridge
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/command"
+	"github.com/0xPolygon/polygon-edge/command/bridge/common"
+	bridgeHelper "github.com/0xPolygon/polygon-edge/command/bridge/helper"
+	polycfg "github.com/0xPolygon/polygon-edge/consensus/polybft/config"
+	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
+	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/e2e-polybft/framework"
+	"github.com/0xPolygon/polygon-edge/helper/hex"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
+	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/Ethernal-Tech/ethgo"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestE2E_Bridge_NetworkFailureAndRestart is an end-to-end test for the bridge functionality
+// in a PolyBFT network. It simulates a network failure and restart scenario to ensure the
+// bridge operates correctly under such conditions. The test performs the following steps:
+//
+//   - Initializes a test cluster with a specified number of validators, bridges, and other configurations.
+//   - Generates accounts and keys for token transfers.
+//   - Deploys and mints ERC20 tokens on both internal and external chains.
+//   - Deposits ERC20 tokens using the bridge and verifies the deposits.
+//   - Simulates a network failure by stopping validators and waits for a block threshold to be reached.
+//   - Restarts the validators and relayer, then performs additional deposits to verify bridge functionality.
+//   - Ensures all events are processed correctly and validates the final token balances on both chains.
+//
+// The test ensures that the bridge can handle network disruptions and continue processing
+// transactions correctly after the network is restored.
+func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
+	const (
+		validatorsCount = 4
+		transfersCount  = 5
+		epochSize       = 10
+		numberOfBridges = 1
+		bridgeAmount    = 100
+		bridgeAmountStr = "100"
+		threshold       = 10
+	)
+
+	accountAddrs := make([]types.Address, transfersCount)
+	accounts := make([]string, transfersCount)
+	accountKeys := make([]string, transfersCount)
+
+	for i := 0; i < transfersCount; i++ {
+		key, err := crypto.GenerateECDSAKey()
+		require.NoError(t, err)
+
+		rawKey, err := key.MarshallPrivateKey()
+		require.NoError(t, err)
+
+		accountKeys[i] = hex.EncodeToString(rawKey)
+		accountAddrs[i] = key.Address()
+		accounts[i] = key.Address().String()
+
+		t.Logf("Receiver#%d=%s\n", i+1, accounts[i])
+	}
+
+	relayerPrivateKey, err := crypto.GenerateECDSAKey()
+	require.NoError(t, err)
+
+	cluster := framework.NewTestCluster(t, validatorsCount,
+		framework.WithBridges(numberOfBridges),
+		framework.WithEpochSize(epochSize),
+		framework.WithBridgeBatchThreshold(threshold),
+		framework.WithRelayerPrivateKey(relayerPrivateKey),
+		framework.WithSecretsCallback(func(addrs []types.Address, tcc *framework.TestClusterConfig) {
+			for i := 0; i < len(addrs); i++ {
+				tcc.StakeAmounts = append(tcc.StakeAmounts, ethgo.Ether(10))
+			}
+
+			tcc.StakeAmounts = append(tcc.StakeAmounts, ethgo.Ether(10))
+
+			tcc.Premine = append(tcc.Premine, accounts...)
+			tcc.Premine = append(tcc.Premine, relayerPrivateKey.String())
+		}),
+	)
+
+	defer cluster.Stop()
+
+	cluster.WaitForReady(t)
+
+	polybftCfg, err := polycfg.LoadPolyBFTConfig(path.Join(cluster.Config.TmpDir, command.DefaultGenesisFileName))
+	require.NoError(t, err)
+
+	internalJSONRPCAddr := cluster.Servers[0].JSONRPCAddr()
+	internalEndpoint := cluster.Servers[0].JSONRPC()
+
+	externalJSONRPCAddr := cluster.Bridges[0].JSONRPCAddr()
+	externalEndpoint, err := jsonrpc.NewEthClient(externalJSONRPCAddr)
+	require.NoError(t, err)
+
+	externalChainTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(externalEndpoint))
+	require.NoError(t, err)
+
+	internalChainTxRelayer, err := txrelayer.NewTxRelayer(txrelayer.WithClient(internalEndpoint))
+	require.NoError(t, err)
+
+	externalChainID, err := externalChainTxRelayer.Client().ChainID()
+	require.NoError(t, err)
+
+	bridgeCfg := polybftCfg.Bridge[externalChainID.Uint64()]
+
+	bridge := cluster.Bridges[0]
+
+	deployerKey, err := bridgeHelper.DecodePrivateKey("")
+	require.NoError(t, err)
+
+	// stop relayer until
+	relayer := cluster.BridgeRelayers[0]
+	relayer.Stop()
+
+	var internalERC20Addr, externalERC20Addr types.Address
+
+	mint := func(token types.Address, amount *big.Int, account types.Address, relayer txrelayer.TxRelayer) error {
+		mintFn := &contractsapi.MintRootERC20Fn{
+			To:     account,
+			Amount: amount,
+		}
+
+		mintInput, err := mintFn.EncodeAbi()
+		if err != nil {
+			return err
+		}
+
+		mintTx := types.NewTx(types.NewLegacyTx(
+			types.WithTo(&token),
+			types.WithInput(mintInput),
+		))
+
+		receipt, err := relayer.SendTransaction(mintTx, deployerKey)
+		if err != nil {
+			return err
+		}
+
+		if receipt == nil || receipt.Status != uint64(types.ReceiptSuccess) {
+			return fmt.Errorf("mint failed")
+		}
+
+		return nil
+	}
+
+	deployAndMint := func(relayer txrelayer.TxRelayer, erc20Addr *types.Address) error {
+		// deploy erc20
+		deployTx := types.NewTx(types.NewLegacyTx(
+			types.WithTo(nil),
+			types.WithInput(contractsapi.RootERC20.Bytecode),
+		))
+
+		receipt, err := relayer.SendTransaction(deployTx, deployerKey)
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+		require.Equal(t, uint64(types.ReceiptSuccess), receipt.Status)
+
+		*erc20Addr = types.Address(receipt.ContractAddress)
+
+		// mint erc20
+		for _, acc := range accountAddrs {
+			if err := mint(*erc20Addr, big.NewInt(bridgeAmount*2), acc, relayer); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	g, _ := errgroup.WithContext(timeoutCtx)
+
+	g.Go(func() error {
+		return deployAndMint(internalChainTxRelayer, &internalERC20Addr)
+	})
+
+	g.Go(func() error {
+		return deployAndMint(externalChainTxRelayer, &externalERC20Addr)
+	})
+
+	if err := g.Wait(); err != nil {
+		t.Fatalf("failed to deploy and mint ERC20: %v", err)
+	}
+
+	cancel()
+
+	t.Logf("Deployed ERC20 contracts & minted tokens")
+
+	runTest := func(erc20Addr, predicateAddr types.Address, rpcAddr string) error {
+		// deposit erc20
+		for i := range transfersCount {
+			if err := bridge.Deposit(
+				common.ERC20,
+				erc20Addr,
+				predicateAddr,
+				accountKeys[i],
+				accounts[i],
+				bridgeAmountStr,
+				"",
+				rpcAddr,
+				"",
+				false,
+			); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	timeoutCtx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+	g, _ = errgroup.WithContext(timeoutCtx)
+
+	g.Go(func() error {
+		return runTest(internalERC20Addr, bridgeCfg.InternalMintableERC20PredicateAddr, internalJSONRPCAddr)
+	})
+
+	g.Go(func() error {
+		return runTest(externalERC20Addr, bridgeCfg.ExternalERC20PredicateAddr, externalJSONRPCAddr)
+	})
+
+	if err := g.Wait(); err != nil {
+		t.Fatalf("failed to deposit ERC20: %v", err)
+	}
+
+	cancel()
+
+	t.Logf("Deposited ERC20 tokens")
+
+	{
+		wg := sync.WaitGroup{}
+		wg.Add(validatorsCount)
+
+		// stop validators
+		for i := range validatorsCount {
+			go func(validatorNum int) {
+				defer wg.Done()
+
+				t.Logf("Stopping validator %d", validatorNum)
+
+				cluster.Servers[validatorNum].Stop()
+			}(i)
+		}
+
+		wg.Wait()
+
+		// wait to reach threshold block
+		block := waitForBlocksOnExternal(t, threshold, externalEndpoint, 3*time.Minute)
+
+		t.Logf("Reached threshold block %d", block)
+
+		wg.Add(validatorsCount)
+
+		// start validators
+		for i := range validatorsCount {
+			go func(validatorNum int) {
+				defer wg.Done()
+
+				t.Logf("Starting validator %d", validatorNum)
+
+				cluster.Servers[validatorNum].Start()
+			}(i)
+		}
+	}
+
+	// start relayer
+	relayer.Start()
+
+	t.Logf("Restarted validators & relayer")
+
+	timeoutCtx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+	g, _ = errgroup.WithContext(timeoutCtx)
+
+	g.Go(func() error {
+		return runTest(internalERC20Addr, bridgeCfg.InternalMintableERC20PredicateAddr, internalJSONRPCAddr)
+	})
+
+	g.Go(func() error {
+		return runTest(externalERC20Addr, bridgeCfg.ExternalERC20PredicateAddr, externalJSONRPCAddr)
+	})
+
+	if err := g.Wait(); err != nil {
+		t.Fatalf("failed to deposit ERC20 after validators restart: %v", err)
+	}
+
+	cancel()
+
+	t.Logf("Deposited ERC20 tokens after validators restart")
+
+	require.NoError(t, cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
+		for i := uint64(1); i <= 2*transfersCount+1; i++ {
+			if !isEventProcessed(t, bridgeCfg.InternalGatewayAddr, internalChainTxRelayer, i, false) {
+				return false
+			}
+
+			if !isEventProcessed(t, bridgeCfg.ExternalGatewayAddr, externalChainTxRelayer, i, false) {
+				return false
+			}
+		}
+
+		return true
+	}))
+
+	t.Logf("Events processed")
+
+	internalChildToken := getChildToken(t, contractsapi.RootERC20Predicate.Abi,
+		bridgeCfg.InternalMintableERC20PredicateAddr, internalERC20Addr, internalChainTxRelayer)
+	externalChildToken := getChildToken(t, contractsapi.RootERC20Predicate.Abi,
+		bridgeCfg.ExternalERC20PredicateAddr, externalERC20Addr, externalChainTxRelayer)
+
+	expectedBalance := big.NewInt(bridgeAmount * 2)
+
+	for _, acc := range accountAddrs {
+		balance1 := erc20BalanceOf(t, acc, internalChildToken, externalChainTxRelayer)
+		if balance1.Cmp(expectedBalance) != 0 {
+			t.Fatalf("expected balance=%d, got=%d", expectedBalance, balance1)
+		}
+
+		balance2 := erc20BalanceOf(t, acc, externalChildToken, internalChainTxRelayer)
+		if balance2.Cmp(expectedBalance) != 0 {
+			t.Fatalf("expected balance=%d, got=%d", expectedBalance, balance2)
+		}
+	}
+
+	t.Logf("Test passed")
+}

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"path"
-	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -352,19 +349,4 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	}
 
 	t.Logf("Test passed")
-}
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
-	parent := filepath.Dir(wd)
-	parent = strings.Trim(parent, "e2e-polybft")
-	wd = filepath.Join(parent, "/artifacts/blade")
-	os.Setenv("EDGE_BINARY", wd)
-	os.Setenv("E2E_TESTS", "true")
-	os.Setenv("E2E_LOGS", "true")
-	os.Setenv("E2E_LOG_LEVEL", "debug")
 }


### PR DESCRIPTION
# Description

This PR introduces a mechanism for persisting and restoring the contents of the unexecuted list and retry maps when the node is restarted. This ensures that batches are not lost during node restarts and can be properly processed after the node starts up.

The batch retry eligibility logic has been modified to use the Event Tracker's `GetLastProcessedBlock` method, improving the accuracy of determining when batches should be moved to the retry state.

To support the persistence functionality, several new BoltDB methods have been implemented: `insertUnexecutedBatch`, `removeUnexecutedBatch`, and `getUnexecutedBatches`. These methods handle the storage and retrieval of batch data, enabling the system to maintain state across restarts.

Comprehensive unit tests have been added (modified) to verify the new functionality, ensuring that the unexecuted batches are properly restored and the retry mechanism works as expected when the node restarts.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [x] I have tested this code manually
