### PR TITLE
Move votes to in-memory store

### DIFF
--- a/consensus/polybft/bridge/bridge.go
+++ b/consensus/polybft/bridge/bridge.go
@@ -96,7 +96,7 @@ func NewBridge(runtime Runtime,
 		chainIDs = append(chainIDs, chainID)
 	}
 
-	store, err := newBridgeManagerStore(state.DB(), dbTx, chainIDs, internalChainID)
+	store, err := newBridgeManagerStore(state.DB(), chainIDs, internalChainID, dbTx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating bridge manager store, err: %w", err)
 	}
@@ -156,15 +156,6 @@ func (b *bridge) PostBlock(req *oracle.PostBlockRequest) error {
 // PostEpoch is a function executed on epoch ending / start of new epoch
 // and calls PostEpoch in each bridge manager
 func (b *bridge) PostEpoch(req *oracle.PostEpochRequest) error {
-	if err := b.state.cleanEpochsFromDB(req.DBTx); err != nil {
-		// we just log this, as it is not critical
-		b.logger.Error("error cleaning epochs from db", "err", err)
-	}
-
-	if err := b.state.insertEpoch(req.NewEpochID, req.DBTx, b.internalChainID); err != nil {
-		return fmt.Errorf("error inserting epoch to internal, err: %w", err)
-	}
-
 	for chainID, bridgeManager := range b.bridgeManagers {
 		if err := bridgeManager.PostEpoch(req); err != nil {
 			return fmt.Errorf("erorr bridge post epoch, chainID: %d, err: %w", chainID, err)

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -321,16 +321,17 @@ func (b *bridgeEventManager) saveVote(vote *BridgeBatchVote) error {
 		return fmt.Errorf("error verifying vote signature: %w", err)
 	}
 
-	if b.votes[types.Hash(vote.Hash[:])] == nil {
-		b.votes[types.Hash(vote.Hash[:])] = make(map[string][]byte)
+	if b.votes[types.Hash(vote.Hash)] == nil {
+		b.votes[types.Hash(vote.Hash)] = make(map[string][]byte)
 	}
-	b.votes[types.Hash(vote.Hash[:])][vote.Sender] = vote.Signature
+
+	b.votes[types.Hash(vote.Hash)][vote.Sender] = vote.Signature
 
 	b.logger.Info(
 		"New vote for bridge batch saved",
 		"batch hash", hex.EncodeToString(vote.Hash),
 		"sender", vote.Sender,
-		"total number of votes for the batch", len(b.votes[types.Hash(vote.Hash[:])]),
+		"total number of votes for the batch", len(b.votes[types.Hash(vote.Hash)]),
 	)
 
 	return nil
@@ -343,6 +344,7 @@ func (b *bridgeEventManager) verifyVoteSignature(
 	vote *BridgeBatchVote) error {
 	signerAddr := types.StringToAddress(vote.Sender)
 	validator := valSet.Accounts().GetValidatorMetadata(signerAddr)
+
 	if validator == nil {
 		return fmt.Errorf("unable to resolve validator %s", signerAddr)
 	}
@@ -554,7 +556,7 @@ func (b *bridgeEventManager) PostBlock(req *oracle.PostBlockRequest) error {
 				"err", err)
 		}
 
-		b.handleRetry(sysState, req.DBTx)
+		b.handleRetry(sysState)
 	}
 
 	return nil
@@ -658,6 +660,7 @@ func (b *bridgeEventManager) buildBridgeBatch(
 	if b.votes[fullHash] == nil {
 		b.votes[fullHash] = make(map[string][]byte)
 	}
+
 	b.votes[fullHash][sig.Sender] = sig.Signature
 	b.lock.Unlock()
 
@@ -706,8 +709,7 @@ func (b *bridgeEventManager) buildBridgeBatch(
 // handleRetry handles the complete logic related to checking whether a batch is ready for retry,
 // as well as building and broadcasting retry candidates.
 func (b *bridgeEventManager) handleRetry(
-	sysState systemstate.SystemState,
-	dbTx *bolt.Tx) {
+	sysState systemstate.SystemState) {
 	blockNumber, err := b.externalTipProvider.GetLastProcessedBlock()
 	if err != nil {
 		// Log the error, but won't return because it might be just a temporary problem.
@@ -780,7 +782,7 @@ func (b *bridgeEventManager) handleRetry(
 
 	// Creating a new retry candidate for each batch that is ready for the retry.
 	for hash := range b.retryBatches {
-		err = b.buildRetryBridgeBatch(hash, blockNumber, dbTx)
+		err = b.buildRetryBridgeBatch(hash, blockNumber)
 		if err != nil {
 			b.logger.Error("could not create retry bridge batch", "err", err)
 		}
@@ -790,8 +792,7 @@ func (b *bridgeEventManager) handleRetry(
 // buildRetryBridgeBatch builds, signs, and multicasts a retry version of the batch.
 func (b *bridgeEventManager) buildRetryBridgeBatch(
 	baseHash types.Hash,
-	blockNumber uint64,
-	dbTx *bolt.Tx) error {
+	blockNumber uint64) error {
 	//
 	// Bulding a retry batch is actually based just on taking a retry template for the given
 	// batch and calculating a new threshold.
@@ -827,6 +828,7 @@ func (b *bridgeEventManager) buildRetryBridgeBatch(
 	if b.votes[hash] == nil {
 		b.votes[hash] = make(map[string][]byte)
 	}
+
 	b.votes[hash][b.config.key.String()] = signature
 	b.lock.Unlock()
 

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -329,7 +329,7 @@ func (b *bridgeEventManager) saveVote(vote *BridgeBatchVote) error {
 
 	b.logger.Info(
 		"New vote for bridge batch saved",
-		"batch hash", hex.EncodeToString(vote.Hash),
+		"batch hash", fmt.Sprintf("0x%v", hex.EncodeToString(vote.Hash)),
 		"sender", vote.Sender,
 		"total number of votes for the batch", len(b.votes[types.Hash(vote.Hash)]),
 	)

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -135,6 +135,7 @@ type bridgeEventManager struct {
 	externalChainID         uint64
 	internalChainID         uint64
 	blockchain              polychain.Blockchain
+	votes                   map[types.Hash]map[string][]byte
 
 	runtime             Runtime
 	tracker             *tracker.EventTracker
@@ -160,6 +161,7 @@ func newBridgeManager(
 		externalChainID:     externalChainID,
 		internalChainID:     internalChainID,
 		blockchain:          blockchain,
+		votes:               make(map[types.Hash]map[string][]byte),
 	}
 
 	bm.restoreUnexecutedBatches(dbTx)
@@ -290,82 +292,69 @@ func (b *bridgeEventManager) initTransport() error {
 	})
 }
 
-// saveVote saves the gotten vote to the boltDB for later quorum check and signature aggregation.
+// saveVotes checks the correctness of the vote, and if everything is fine, saves it.
 func (b *bridgeEventManager) saveVote(vote *BridgeBatchVote) error {
-	b.lock.RLock()
-	epoch := b.epoch
-	valSet := b.validatorSet
-	b.lock.RUnlock()
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
-	if valSet == nil || vote.EpochNumber < epoch || vote.EpochNumber > epoch+1 {
-		// Epoch metadata is undefined or received a vote for the irrelevant epoch.
+	// Check if the validator set for the current epoch is known. If not, we cannot process the
+	// newly arrived vote.
+	if b.validatorSet == nil {
 		return nil
 	}
 
-	if !b.isRelevantChainID(vote.SourceChainID) || !b.isRelevantChainID(vote.DestinationChainID) {
-		// Vote is for irrelevant chain, skip it.
+	// We are only interested in votes from the epoch we are currently in.
+	if vote.EpochNumber != b.epoch {
 		return nil
 	}
 
-	if vote.EpochNumber == epoch+1 {
-		if err := b.state.insertEpoch(epoch+1, nil, vote.SourceChainID); err != nil {
-			return fmt.Errorf("error saving msg vote from a future epoch: %d. Error: %w", epoch+1, err)
-		}
+	// If the vote arrives for the bridge path (internal chain <-> external chain) that is not
+	// managed by this bridge manager, it should be immediately discarded (it will be processed
+	// by the appropriate manager).
+	if b.externalChainID != vote.SourceChainID &&
+		b.externalChainID != vote.DestinationChainID {
+		return nil
 	}
 
-	if err := b.verifyVoteSignature(valSet,
-		types.StringToAddress(vote.Sender), vote.Signature, vote.Hash); err != nil {
+	// Check if the signature is valid and if the signer is a validator in the current epoch.
+	if err := b.verifyVoteSignature(b.validatorSet, vote); err != nil {
 		return fmt.Errorf("error verifying vote signature: %w", err)
 	}
 
-	msgVote := &BridgeBatchVoteConsensusData{
-		Sender:    vote.Sender,
-		Signature: vote.Signature,
+	if b.votes[types.Hash(vote.Hash[:])] == nil {
+		b.votes[types.Hash(vote.Hash[:])] = make(map[string][]byte)
 	}
-
-	numSignatures, err := b.state.insertConsensusData(
-		vote.EpochNumber,
-		vote.Hash,
-		msgVote,
-		nil,
-		vote.SourceChainID)
-	if err != nil {
-		return fmt.Errorf("error inserting message vote: %w", err)
-	}
+	b.votes[types.Hash(vote.Hash[:])][vote.Sender] = vote.Signature
 
 	b.logger.Info(
-		"deliver message",
-		"hash", hex.EncodeToString(vote.Hash),
+		"New vote for bridge batch saved",
+		"batch hash", hex.EncodeToString(vote.Hash),
 		"sender", vote.Sender,
-		"signatures", numSignatures,
+		"total number of votes for the batch", len(b.votes[types.Hash(vote.Hash[:])]),
 	)
 
 	return nil
-}
-
-// isRelevantChainID checks whether internal or external chain id corresponds to the given chain ID.
-func (b *bridgeEventManager) isRelevantChainID(chainID uint64) bool {
-	return b.internalChainID == chainID || b.externalChainID == chainID
 }
 
 // verifyVoteSignature verifies signature of the message against the public key of the signer and
 // checks if the signer is a validator.
 func (b *bridgeEventManager) verifyVoteSignature(
 	valSet validator.ValidatorSet,
-	signerAddr types.Address,
-	signature []byte,
-	hash []byte) error {
+	vote *BridgeBatchVote) error {
+	signerAddr := types.StringToAddress(vote.Sender)
 	validator := valSet.Accounts().GetValidatorMetadata(signerAddr)
 	if validator == nil {
 		return fmt.Errorf("unable to resolve validator %s", signerAddr)
 	}
 
-	unmarshaledSignature, err := bls.UnmarshalSignature(signature)
+	unmarshaledSignature, err := bls.UnmarshalSignature(vote.Signature)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal signature from signer %s, %w", signerAddr.String(), err)
+		return fmt.Errorf("failed to unmarshal signature from signer %s, %w",
+			signerAddr.String(),
+			err)
 	}
 
-	if !unmarshaledSignature.Verify(validator.BlsKey, hash, signer.DomainBridge) {
+	if !unmarshaledSignature.Verify(validator.BlsKey, vote.Hash, signer.DomainBridge) {
 		return fmt.Errorf("incorrect signature from %s", signerAddr)
 	}
 
@@ -453,10 +442,11 @@ func (b *bridgeEventManager) BridgeBatch(blockNumber uint64) ([]*BridgeBatchSign
 func (b *bridgeEventManager) getAggSignatureForBridgeBatch(
 	blockNumber uint64,
 	pendingBridgeBatch *PendingBridgeBatch) (polytypes.Signature, error) {
-	validatorSet := b.validatorSet
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
-	validatorAddrToIndex := make(map[string]int, validatorSet.Len())
-	validatorsMetadata := validatorSet.Accounts()
+	validatorAddrToIndex := make(map[string]int, b.validatorSet.Len())
+	validatorsMetadata := b.validatorSet.Accounts()
 
 	for i, validator := range validatorsMetadata {
 		validatorAddrToIndex[validator.Address.String()] = i
@@ -467,13 +457,13 @@ func (b *bridgeEventManager) getAggSignatureForBridgeBatch(
 		return polytypes.Signature{}, err
 	}
 
-	// Get all the votes from the database for batch.
-	votes, err := b.state.getMessageVotes(
-		pendingBridgeBatch.Epoch,
-		bridgeBatchHash.Bytes(),
-		pendingBridgeBatch.BridgeMessageBatch.SourceChainID.Uint64())
-	if err != nil {
-		return polytypes.Signature{}, err
+	votes := []*BridgeBatchVoteConsensusData{}
+
+	for sender, signature := range b.votes[bridgeBatchHash] {
+		votes = append(votes, &BridgeBatchVoteConsensusData{
+			Sender:    sender,
+			Signature: signature,
+		})
 	}
 
 	var (
@@ -500,7 +490,7 @@ func (b *bridgeEventManager) getAggSignatureForBridgeBatch(
 		signers[types.StringToAddress(vote.Sender)] = struct{}{}
 	}
 
-	if !validatorSet.HasQuorum(blockNumber, signers) {
+	if !b.validatorSet.HasQuorum(blockNumber, signers) {
 		return polytypes.Signature{}, errQuorumNotReached
 	}
 
@@ -520,16 +510,6 @@ func (b *bridgeEventManager) getAggSignatureForBridgeBatch(
 // PostEpoch notifies the bridge event manager that an epoch has changed, so that it can discard
 // any previous epoch bridge batch, and build a new one (since validator set changed)
 func (b *bridgeEventManager) PostEpoch(req *oracle.PostEpochRequest) error {
-	if err := b.state.insertEpoch(req.NewEpochID, req.DBTx, b.externalChainID); err != nil {
-		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w",
-			b.externalChainID, err)
-	}
-
-	if err := b.state.insertEpoch(req.NewEpochID, req.DBTx, b.internalChainID); err != nil {
-		return fmt.Errorf("an error occurred while inserting new epoch in db, chainID: %d. Reason: %w",
-			b.internalChainID, err)
-	}
-
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -537,6 +517,7 @@ func (b *bridgeEventManager) PostEpoch(req *oracle.PostEpochRequest) error {
 	b.pendingBridgeBatchesI2E = nil
 	b.validatorSet = req.ValidatorSet
 	b.epoch = req.NewEpochID
+	b.votes = make(map[types.Hash]map[string][]byte)
 
 	return nil
 }
@@ -673,9 +654,12 @@ func (b *bridgeEventManager) buildBridgeBatch(
 		Signature: signature,
 	}
 
-	if _, err = b.state.insertConsensusData(epoch, hashBytes, sig, dbTx, sourceChainID); err != nil {
-		return fmt.Errorf("could not insert signature for bridge batch. Error: %w", err)
+	b.lock.Lock()
+	if b.votes[fullHash] == nil {
+		b.votes[fullHash] = make(map[string][]byte)
 	}
+	b.votes[fullHash][sig.Sender] = sig.Signature
+	b.lock.Unlock()
 
 	b.multicast(&BridgeBatchVote{
 		Hash: hashBytes,
@@ -839,14 +823,12 @@ func (b *bridgeEventManager) buildRetryBridgeBatch(
 		return fmt.Errorf("could not create a signature for retry bridge batch. Error: %w", err)
 	}
 
-	sig := &BridgeBatchVoteConsensusData{
-		Sender:    b.config.key.String(),
-		Signature: signature,
+	b.lock.Lock()
+	if b.votes[hash] == nil {
+		b.votes[hash] = make(map[string][]byte)
 	}
-
-	if _, err = b.state.insertConsensusData(b.epoch, hashBytes, sig, dbTx, b.internalChainID); err != nil {
-		return fmt.Errorf("could not insert signature for retry bridge batch. Error: %w", err)
-	}
+	b.votes[hash][b.config.key.String()] = signature
+	b.lock.Unlock()
 
 	b.multicast(&BridgeBatchVote{
 		Hash: hashBytes,
@@ -1247,7 +1229,7 @@ func (b *bridgeEventManager) AddLog(
 
 	// It's important to first start (open) the bolt DB write transaction and only then lock the
 	// mutex. Otherwise, there is a possibility of a deadlock occurring.
-	dbTx, err := b.state.BeginDBTransaction(true)
+	dbTx, err := b.state.beginDBTransaction(true)
 	if err != nil {
 		return err
 	}

--- a/consensus/polybft/bridge/bridge_manager_test.go
+++ b/consensus/polybft/bridge/bridge_manager_test.go
@@ -67,11 +67,15 @@ func newTestState(t *testing.T) *BridgeManagerStore {
 	return store
 }
 
-func newTestBridgeManager(t *testing.T, key *validator.TestValidator, runtime Runtime, tipProvider ChainTipProvider, blockchain blockchain.Blockchain) *bridgeEventManager {
+func newTestBridgeManager(
+	t *testing.T,
+	key *validator.TestValidator,
+	runtime Runtime,
+	tipProvider ChainTipProvider,
+	blockchain blockchain.Blockchain) *bridgeEventManager {
 	t.Helper()
 
 	state := newTestState(t)
-	require.NoError(t, state.insertEpoch(0, nil, 1))
 
 	topic := &mockTopic{}
 
@@ -153,144 +157,193 @@ func TestBridgeEventManager_PostEpoch_BuildBridgeBatch(t *testing.T) {
 	})
 }
 
-func TestBridgeEventManager_MessagePool(t *testing.T) {
-	t.Parallel()
-
+//nolint:tparallel
+func Test_saveVote(t *testing.T) {
 	vals := validator.NewTestValidators(t, 5)
 
 	blockchain := new(blockchain.BlockchainMock)
 	blockchain.On("CurrentHeader").Return(&types.Header{Number: 10})
 
-	t.Run("Old epoch", func(t *testing.T) {
+	// This test illustrates a scenario where votes from epochs different from the current epoch
+	// arrive in the system.
+	//
+	// Expected: the votes should be rejected, i.e., the vote count should remain 0.
+	t.Run("1", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
+		bm := newTestBridgeManager(t,
+			vals.GetValidator("0"),
+			&mockRuntime{isActiveValidator: true},
+			nil,
+			nil)
 
-		s.epoch = 1
+		bm.validatorSet = vals.ToValidatorSet()
+
+		bm.epoch = 2
 		msg := &BridgeBatchVote{
-			EpochNumber: 0,
+			EpochNumber: 3,
 		}
 
-		err := s.saveVote(msg)
+		err := bm.saveVote(msg)
+
 		require.NoError(t, err)
+
+		bm.epoch = 2
+		msg = &BridgeBatchVote{
+			EpochNumber: 1,
+		}
+
+		err = bm.saveVote(msg)
+
+		require.NoError(t, err)
+
+		require.Len(t, bm.votes, 0)
 	})
 
-	t.Run("Sender is not a validator", func(t *testing.T) {
+	// This test illustrates a scenario where a vote arrives from a non-validator.
+	//
+	// Expected: the vote should be rejected, i.e., the vote count should remain 0.
+	t.Run("2", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
-		s.validatorSet = vals.ToValidatorSet()
+		bm := newTestBridgeManager(t,
+			vals.GetValidator("0"),
+			&mockRuntime{isActiveValidator: true},
+			nil,
+			nil)
 
-		badVal := validator.NewTestValidator(t, "a", 0)
-		msg, err := newMockMsg().sign(badVal, signer.DomainBridge)
+		bm.validatorSet = vals.ToValidatorSet()
+
+		badValidator := validator.NewTestValidator(t, "a", 0)
+		msg, err := newMockMsg().sign(badValidator, signer.DomainBridge)
 		require.NoError(t, err)
 
 		msg.SourceChainID = 1
-		msg.DestinationChainID = 100
 
-		require.Error(t, s.saveVote(msg))
+		require.Error(t, bm.saveVote(msg))
 	})
 
-	t.Run("Invalid epoch", func(t *testing.T) {
+	// This test illustrates a scenario where a vote is sent by a validator, but the signature
+	// is invalid.
+	//
+	// Expected: the vote should be rejected, i.e., the vote count should remain 0.
+	t.Run("3", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
-		s.validatorSet = vals.ToValidatorSet()
+		bm := newTestBridgeManager(t,
+			vals.GetValidator("0"),
+			&mockRuntime{isActiveValidator: true},
+			nil,
+			nil)
 
-		val := newMockMsg()
-		msg, err := val.sign(vals.GetValidator("0"), signer.DomainBridge)
+		bm.validatorSet = vals.ToValidatorSet()
+
+		// Case 1: Validator signs the message in behalf of another validator.
+		msg1 := newMockMsg()
+		sigMsg1, err := msg1.sign(vals.GetValidator("0"), signer.DomainBridge)
 		require.NoError(t, err)
 
-		// invalid epoch +2
-		msg.EpochNumber = 2
+		sigMsg1.SourceChainID = 1
 
-		require.NoError(t, s.saveVote(msg))
+		sigMsg1.Sender = vals.GetValidator("1").Address().String()
+		require.Error(t, bm.saveVote(sigMsg1))
 
-		// no votes for the current epoch
-		votes, err := s.state.getMessageVotes(0, msg.Hash, 1)
+		// Case 2: Non-validator signs the message in behalf of a validator.
+		msg2 := validator.NewTestValidator(t, "a", 0)
+		sigMsg2, err := newMockMsg().sign(msg2, signer.DomainBridge)
 		require.NoError(t, err)
-		require.Len(t, votes, 0)
 
-		// returns an error for the invalid epoch
-		_, err = s.state.getMessageVotes(1, msg.Hash, 1)
-		require.Error(t, err)
+		sigMsg2.SourceChainID = 1
+
+		sigMsg2.Sender = vals.GetValidator("1").Address().String()
+		require.Error(t, bm.saveVote(sigMsg2))
 	})
 
-	t.Run("Sender and signature mismatch", func(t *testing.T) {
+	// This test illustrates a scenario where two (or more) votes for the same batch arrive from
+	// the same validator.
+	//
+	// Expected: the vote should be stored only once.
+	t.Run("4", func(t *testing.T) {
 		t.Parallel()
 
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
-		s.validatorSet = vals.ToValidatorSet()
+		bm := newTestBridgeManager(t,
+			vals.GetValidator("0"),
+			&mockRuntime{isActiveValidator: true},
+			nil,
+			nil)
 
-		// validator signs the msg in behalf of another validator
-		val := newMockMsg()
-		msg, err := val.sign(vals.GetValidator("0"), signer.DomainBridge)
-		require.NoError(t, err)
-
-		msg.SourceChainID = 1
-		msg.DestinationChainID = 100
-
-		msg.Sender = vals.GetValidator("1").Address().String()
-		require.Error(t, s.saveVote(msg))
-
-		// non validator signs the msg in behalf of a validator
-		badVal := validator.NewTestValidator(t, "a", 0)
-		msg, err = newMockMsg().sign(badVal, signer.DomainBridge)
-		require.NoError(t, err)
-
-		msg.SourceChainID = 1
-		msg.DestinationChainID = 100
-
-		msg.Sender = vals.GetValidator("1").Address().String()
-		require.Error(t, s.saveVote(msg))
-	})
-
-	t.Run("Sender votes", func(t *testing.T) {
-		t.Parallel()
-
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
-		s.validatorSet = vals.ToValidatorSet()
+		bm.validatorSet = vals.ToValidatorSet()
 
 		msg := newMockMsg()
 		val1signed, err := msg.sign(vals.GetValidator("1"), signer.DomainBridge)
 		require.NoError(t, err)
 
 		val1signed.SourceChainID = 1
-		val1signed.DestinationChainID = 100
 
 		val2signed, err := msg.sign(vals.GetValidator("2"), signer.DomainBridge)
 		require.NoError(t, err)
 
 		val2signed.SourceChainID = 1
-		val2signed.DestinationChainID = 100
 
-		// vote with validator 1
-		require.NoError(t, s.saveVote(val1signed))
+		require.NoError(t, bm.saveVote(val1signed))
+		require.NoError(t, bm.saveVote(val1signed))
+		require.NoError(t, bm.saveVote(val1signed))
 
-		votes, err := s.state.getMessageVotes(0, msg.hash, 1)
-		require.NoError(t, err)
-		require.Len(t, votes, 1)
+		require.Len(t, bm.votes[types.Hash(val1signed.Hash)], 1)
 
-		// vote with validator 1 again (the votes do not increase)
-		require.NoError(t, s.saveVote(val1signed))
-		votes, _ = s.state.getMessageVotes(0, msg.hash, 1)
-		require.Len(t, votes, 1)
+		require.NoError(t, bm.saveVote(val2signed))
+		require.NoError(t, bm.saveVote(val2signed))
 
-		// vote with validator 2
-		require.NoError(t, s.saveVote(val2signed))
-		votes, _ = s.state.getMessageVotes(0, msg.hash, 1)
-		require.Len(t, votes, 2)
+		require.Len(t, bm.votes[types.Hash(val1signed.Hash)], 2)
+	})
+
+	// This test illustrates a scenario where a vote arrives for a bridge path that the given
+	// bridge manager is not responsible for.
+	//
+	// Expected: the vote should be rejected.
+	t.Run("5", func(t *testing.T) {
+		t.Parallel()
+
+		bm := newTestBridgeManager(t,
+			vals.GetValidator("0"),
+			&mockRuntime{isActiveValidator: true},
+			nil,
+			nil)
+
+		bm.validatorSet = vals.ToValidatorSet()
+
+		msg := &BridgeBatchVote{
+			SourceChainID:      20,
+			DestinationChainID: 30,
+		}
+
+		require.NoError(t, bm.saveVote(msg))
+
+		require.Len(t, bm.votes, 0)
 	})
 }
 
-func TestBridgeEventManager_BuildBridgeBatch(t *testing.T) {
+func Test_BridgeBatch(t *testing.T) {
 	vals := validator.NewTestValidators(t, 5)
 
-	s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, nil)
-	s.validatorSet = vals.ToValidatorSet()
+	// This test illustrates the quorum-based behavior of the BridgeBatch function.
+	//
+	// 1. Initially, there are no batches in the pending list, so BridgeBatch returns nothing.
+	// 2. A batch is added to the pending list, and two validators (0 and 1) vote for it.
+	// 3. Since there is no quorum, BridgeBatch still returns nothing.
+	// 4. Two more validators (2 and 3) vote for the batch.
+	// 5. With quorum now reached, BridgeBatch returns the given batch.
 
-	// batches are empty
-	batches, err := s.BridgeBatch(1)
+	bm := newTestBridgeManager(t,
+		vals.GetValidator("0"),
+		&mockRuntime{isActiveValidator: true},
+		nil,
+		nil)
+
+	bm.validatorSet = vals.ToValidatorSet()
+
+	// Step 1.
+	batches, err := bm.BridgeBatch(1)
 	require.NoError(t, err)
 	require.Len(t, batches, 0)
 
@@ -309,17 +362,17 @@ func TestBridgeEventManager_BuildBridgeBatch(t *testing.T) {
 		CommitCounter:      big.NewInt(1),
 	}
 
-	s.pendingBridgeBatchesE2I = []*PendingBridgeBatch{
+	// Step 2.
+	bm.pendingBridgeBatchesE2I = []*PendingBridgeBatch{
 		{&bridgeMessageBatch, 0},
 	}
 
-	hash, err := s.pendingBridgeBatchesE2I[0].Hash()
+	hash, err := bm.pendingBridgeBatchesE2I[0].Hash()
 	require.NoError(t, err)
 
 	msg := newMockMsg().WithHash(hash.Bytes())
 
-	// validators 0 and 1 vote for the proposal, there is not enough
-	// voting power for the proposal
+	// Step 3.
 	signedMsg1, err := msg.sign(vals.GetValidator("0"), signer.DomainBridge)
 	require.NoError(t, err)
 
@@ -332,15 +385,16 @@ func TestBridgeEventManager_BuildBridgeBatch(t *testing.T) {
 	signedMsg2.SourceChainID = 1
 	signedMsg2.DestinationChainID = 100
 
-	require.NoError(t, s.saveVote(signedMsg1))
-	require.NoError(t, s.saveVote(signedMsg2))
+	require.NoError(t, bm.saveVote(signedMsg1))
+	require.NoError(t, bm.saveVote(signedMsg2))
 
-	batches, err = s.BridgeBatch(0)
-	require.NoError(t, err) // there is no error if quorum is not met, since its a valid case
+	batches, err = bm.BridgeBatch(1)
+
+	// There is no error if quorum is not met, since it's a valid case.
+	require.NoError(t, err)
 	require.Len(t, batches, 0)
 
-	// validator 2 and 3 vote for the proposal, there is enough voting power now
-
+	// Step 4.
 	signedMsg1, err = msg.sign(vals.GetValidator("2"), signer.DomainBridge)
 	require.NoError(t, err)
 
@@ -353,47 +407,14 @@ func TestBridgeEventManager_BuildBridgeBatch(t *testing.T) {
 	signedMsg2.SourceChainID = 1
 	signedMsg2.DestinationChainID = 100
 
-	require.NoError(t, s.saveVote(signedMsg1))
-	require.NoError(t, s.saveVote(signedMsg2))
+	require.NoError(t, bm.saveVote(signedMsg1))
+	require.NoError(t, bm.saveVote(signedMsg2))
 
-	batches, err = s.BridgeBatch(1)
+	// Step 5.
+	batches, err = bm.BridgeBatch(1)
 	require.NoError(t, err)
 	require.NotNil(t, batches)
-}
-
-func TestBridgeEventManager_RemoveProcessedEvents(t *testing.T) {
-	const bridgeMessageEventsCount = 5
-
-	sysState := new(systemstate.SystemStateMock)
-	sysState.On("GetNextCommittedIndex").Return(uint64(1000))
-
-	blockchain := new(blockchain.BlockchainMock)
-	blockchain.On("GetStateProviderForBlock", mock.Anything).Return(nil)
-	blockchain.On("GetSystemState", mock.Anything).Return(sysState)
-	blockchain.On("CurrentHeader", mock.Anything).Return(&types.Header{Number: 10})
-
-	vals := validator.NewTestValidators(t, 5)
-
-	s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, blockchain)
-	bridgeMessageEvents := generateBridgeMessageEvents(t, bridgeMessageEventsCount, 1)
-
-	for _, event := range bridgeMessageEvents {
-		require.NoError(t, s.state.insertBridgeMessageEvent(event, false, nil))
-	}
-
-	bridgeMessageEventsBefore, err := s.state.list(s.internalChainID)
-	require.NoError(t, err)
-	require.Equal(t, bridgeMessageEventsCount, len(bridgeMessageEventsBefore))
-
-	for _, event := range bridgeMessageEvents {
-		eventLog := createTestLogForBridgeMessageResultEvent(t, event.ID.Uint64())
-		require.NoError(t, s.ProcessLog(&types.Header{Number: 10}, eventLog, nil))
-	}
-
-	// all bridge message events and their proofs should be removed from the store
-	stateSyncEventsAfter, err := s.state.list(s.internalChainID)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(stateSyncEventsAfter))
+	require.Len(t, batches, 1)
 }
 
 func Test_restore_Unexecuted_and_Retry_Batches(t *testing.T) {
@@ -523,7 +544,7 @@ func Test_restore_Unexecuted_and_Retry_Batches(t *testing.T) {
 	require.Contains(t, presentHashes, fullHash1)
 	require.Contains(t, presentHashes, fullHash2)
 
-	bm.handleRetry(ss, nil)
+	bm.handleRetry(ss)
 
 	require.EqualValues(t, 1, len(bm.unexecutedBatches))
 	require.EqualValues(t, 1, len(bm.retryBatches))
@@ -2403,7 +2424,7 @@ func Test_handleRetry(t *testing.T) {
 
 		require.NoError(t, err)
 
-		bm.handleRetry(ss, nil)
+		bm.handleRetry(ss)
 
 		checkFn(bm, 1, 2, false)
 	})
@@ -2435,157 +2456,10 @@ func Test_handleRetry(t *testing.T) {
 
 		require.NoError(t, err)
 
-		bm.handleRetry(ss, nil)
+		bm.handleRetry(ss)
 
 		checkFn(bm, 2, 1, true)
 	})
-}
-
-func TestBridgeEventManager_AddLog_BuildBridgeBatches(t *testing.T) {
-	t.Parallel()
-
-	vals := validator.NewTestValidators(t, 5)
-
-	t.Run("Node is a validator", func(t *testing.T) {
-		t.Skip()
-		t.Parallel()
-
-		blockchain := new(blockchain.BlockchainMock)
-
-		blockchain.On("CurrentHeader").Return(&types.Header{Number: 10})
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: true}, nil, blockchain)
-
-		postBlockRequest := &oracle.PostBlockRequest{
-			FullBlock: &types.FullBlock{
-				Block: &types.Block{
-					Header: &types.Header{Number: 0}}}}
-
-		bridgeMsg := &contractsapi.BridgeMsgEvent{ID: bigZero, SourceChainID: big.NewInt(1), DestinationChainID: bigZero}
-		bridgeMsgData, err := bridgeMsg.Encode()
-		require.NoError(t, err)
-
-		// log with the bridge message topic but incorrect content
-		require.Error(t, s.AddLog(big.NewInt(1), &ethgo.Log{Topics: []ethgo.Hash{bridgeMessageEventSig}, Data: bridgeMsgData}))
-		bridgeEvents, err := s.state.list(100)
-
-		require.NoError(t, err)
-		require.Len(t, bridgeEvents, 0)
-
-		// correct event log
-		data, err := abi.MustNewType("tuple(uint256 a, uint256 b, string c)").Encode([]string{"1", "100", "data"})
-		require.NoError(t, err)
-
-		goodLog := &ethgo.Log{
-			Topics: []ethgo.Hash{
-				bridgeMessageEventSig,
-				ethgo.BytesToHash([]byte{0x1}), // bridge message index 1
-				ethgo.ZeroHash,
-				ethgo.ZeroHash,
-			},
-			Data: data,
-		}
-
-		require.NoError(t, s.AddLog(big.NewInt(1), goodLog))
-
-		require.NoError(t, s.PostBlock(postBlockRequest))
-
-		length := len(s.pendingBridgeBatchesE2I[0].Messages)
-
-		bridgeMessages, _, err := s.state.getBridgeMessages(1, 1, 1, 100, nil, nil)
-		require.NoError(t, err)
-		require.Len(t, bridgeMessages, 1)
-		require.Len(t, s.pendingBridgeBatchesE2I, 1)
-		require.Equal(t, uint64(1), s.pendingBridgeBatchesE2I[0].Messages[0].ID.Uint64())
-		require.Equal(t, uint64(1), s.pendingBridgeBatchesE2I[0].Messages[length-1].ID.Uint64())
-
-		// add one more log to have a minimum batch
-		goodLog2 := goodLog.Copy()
-		goodLog2.Topics[1] = ethgo.BytesToHash([]byte{0x2}) // bridgeMsg event index 1
-		require.NoError(t, s.AddLog(big.NewInt(1), goodLog2))
-
-		require.NoError(t, s.PostBlock(postBlockRequest))
-
-		length = len(s.pendingBridgeBatchesE2I[1].Messages)
-
-		require.Len(t, s.pendingBridgeBatchesE2I, 2)
-		require.Equal(t, uint64(1), s.pendingBridgeBatchesE2I[1].Messages[0].ID.Uint64())
-		require.Equal(t, uint64(2), s.pendingBridgeBatchesE2I[1].Messages[length-1].ID.Uint64())
-
-		// add two more logs to have larger batch
-		goodLog3 := goodLog.Copy()
-		goodLog3.Topics[1] = ethgo.BytesToHash([]byte{0x3}) // bridgeMsg event index 2
-		require.NoError(t, s.AddLog(big.NewInt(1), goodLog3))
-
-		require.NoError(t, s.PostBlock(postBlockRequest))
-
-		goodLog4 := goodLog.Copy()
-		goodLog4.Topics[1] = ethgo.BytesToHash([]byte{0x4}) // bridgeMsg event index 3
-		require.NoError(t, s.AddLog(big.NewInt(1), goodLog4))
-
-		require.NoError(t, s.PostBlock(postBlockRequest))
-
-		length = len(s.pendingBridgeBatchesE2I[3].Messages)
-
-		require.Len(t, s.pendingBridgeBatchesE2I, 4)
-		require.Equal(t, uint64(1), s.pendingBridgeBatchesE2I[3].Messages[0].ID.Uint64())
-		require.Equal(t, uint64(4), s.pendingBridgeBatchesE2I[3].Messages[length-1].ID.Uint64())
-	})
-
-	t.Run("Node is not a validator", func(t *testing.T) {
-		t.Parallel()
-
-		sysState := new(systemstate.SystemStateMock)
-		sysState.On("GetNextCommittedIndex").Return(uint64(1000))
-
-		blockchain := new(blockchain.BlockchainMock)
-		blockchain.On("GetStateProviderForBlock", mock.Anything).Return(nil)
-		blockchain.On("GetSystemState", mock.Anything).Return(sysState)
-		blockchain.On("CurrentHeader", mock.Anything).Return(&types.Header{Number: 10})
-
-		s := newTestBridgeManager(t, vals.GetValidator("0"), &mockRuntime{isActiveValidator: false}, nil, blockchain)
-
-		// correct event log
-		data, err := abi.MustNewType("tuple(uint256 a, uint256 b, string c)").Encode([]string{"1", "100", "data"})
-		require.NoError(t, err)
-
-		var bridgeMessageEvent contractsapi.BridgeMsgEvent
-
-		goodLog := &ethgo.Log{
-			Topics: []ethgo.Hash{
-				bridgeMessageEvent.Sig(),
-				ethgo.BytesToHash([]byte{0x1}), // bridge message index 0
-				ethgo.ZeroHash,
-				ethgo.ZeroHash,
-			},
-			Data: data,
-		}
-
-		require.NoError(t, s.AddLog(big.NewInt(1), goodLog))
-
-		// node should have inserted given bridgeMsg event, but it shouldn't build any batch
-		bridgeMessages, _, err := s.state.getBridgeMessages(1, 1, 1, 100, nil, nil)
-		require.NoError(t, err)
-		require.Len(t, bridgeMessages, 1)
-		require.Equal(t, uint64(1), bridgeMessages[0].ID.Uint64())
-		require.Len(t, s.pendingBridgeBatchesE2I, 0)
-	})
-}
-
-func createTestLogForBridgeMessageResultEvent(t *testing.T, bridgeMessageEventID uint64) *ethgo.Log {
-	t.Helper()
-
-	data, err := abi.MustNewType("tuple(uint256 a, uint256 b, bool c, bytes d)").Encode(
-		[]interface{}{big.NewInt(1), big.NewInt(100), false, []byte("")})
-	require.NoError(t, err)
-
-	return &ethgo.Log{
-		Topics: []ethgo.Hash{
-			bridgeMessageResultEventSig,
-			ethgo.BytesToHash(common.EncodeUint64ToBytes(bridgeMessageEventID)),
-			ethgo.BytesToHash(common.EncodeUint64ToBytes(1)),
-		},
-		Data: data,
-	}
 }
 
 type mockTopic struct {

--- a/consensus/polybft/bridge/bridge_manager_test.go
+++ b/consensus/polybft/bridge/bridge_manager_test.go
@@ -59,7 +59,7 @@ func newTestState(t *testing.T) *BridgeManagerStore {
 		chainIds = append(chainIds, i)
 	}
 
-	store, err := newBridgeManagerStore(db, nil, chainIds, 100)
+	store, err := newBridgeManagerStore(db, chainIds, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2688,10 +2688,6 @@ func (*mockBridgeManager) PostBlock(req *oracle.PostBlockRequest) error {
 
 // PostEpoch implements BridgeManager.
 func (mbm *mockBridgeManager) PostEpoch(req *oracle.PostEpochRequest) error {
-	if err := mbm.state.insertEpoch(req.NewEpochID, req.DBTx, mbm.chainID); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/consensus/polybft/bridge/state_store_bridge_message.go
+++ b/consensus/polybft/bridge/state_store_bridge_message.go
@@ -13,27 +13,72 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+// The following variables denote the names of all buckets within the bolt DB used to implement
+// bridging logic (see newBridgeManagerStore for more details about buckets structure).
 var (
-	// bucket to store bridge events
-	bridgeMessageEventsBucket = []byte("bridgeMessageEvents")
-	// bucket to store bridge buckets
-	bridgeBatchBucket = []byte("bridgeBatches")
-	// bucket to store message votes (signatures)
-	messageVotesBucket = []byte("votes")
-	// bucket to store epochs and all its nested buckets (message votes and message pool events)
-	epochsBucket = []byte("epochs")
+	// bridgeMessages (int. name "bridgeMessages") is the root bucket of the tree structure that
+	// contains all the necessary buckets for proper coordination of the operations related to
+	// the bridge messages, such as handling ordinary and rollback messages, denoting messages
+	// as executed, and more.
+	bridgeMessages = []byte("bridgeMessages")
 
-	unexecutedBatches = []byte("unexecuted")
-
+	// ordinaryMessages (int. name "ordinary") is a bucket that contains all ordinary messages
+	// that need to be transferred to the destination chain and executed there. This bucket is
+	// part of the bucket tree structure that starts with the "bridgeMessages" bucket. It is at
+	// the same level in the tree as the "rollbackMessages" and "executedMessages" buckets. The
+	// message is written to the bucket when a `BridgeMsg` event occurs on the source chain and
+	// is removed upon its execution (successful or unsuccessful) on the destination chain, i.e.
+	// when a `BridgeMessageResult` event occurs. See BridgeManager ProcessLog/AddLog methods for
+	// more details on when these events are triggered. The key in the bucket represents the ID
+	// of the message, while the value is the content of the `BridgeMsg` event (more precisely,
+	// its struct representation in Go). Note, it is also used within "executedMessages" bucket
+	// (read doc for "executedMessages" for more info).
 	ordinaryMessages = []byte("ordinary")
+
+	// rollbackMessages (int. name "rollback") is a bucket that contains all rollback messages
+	// that need to be transferred to the destination chain and executed there. This bucket is
+	// part of the bucket tree structure that starts with the "bridgeMessages" bucket. It is at
+	// the same level in the tree as the "ordinaryMessages" and "executedMessages" buckets. If
+	// the ordinary message fails to execute on the destination chain (incidated by the emission
+	// of a `BridgeMessageResult` event with the status field set to "false"), then it becomes
+	// a rollback message and is written to this bucket. A message is removed from the bucket
+	// once it is committed to the BridgeStorage. The key in the bucket represents the message
+	// ID, while the value is the content of the `BridgeMsg` event (more precisely, its struct
+	// representation in Go) - the same as in the "ordinaryMessages" bucket. Note, it is also
+	// used within "executedMessages" bucket (read doc for "executedMessages" for more info).
 	rollbackMessages = []byte("rollback")
 
+	// executedMessages (int. name "executed") is a bucket that contains results of all messages
+	// that have been executed (successfully or unsuccessfully) on the destination chain. This
+	// bucket is part of the bucket structure that starts with the "bridgeMessages" bucket. It
+	// is at the same level in the tree as the "ordinaryMessages" and "rollbackMessages" buckets.
+	// The bucket consists of two sub-buckets: "ordinaryMessages" and "rollbackMessages". These
+	// names are only used for categorization and are not related to the previously described
+	// buckets with the same names. The execution result of a message is written to the bucket
+	// upon its execution on the destination chain, that is, when a `BridgeMessageResult` event
+	// occurs. If the message was an ordinary message, its execution result is stored in the
+	// "ordinaryMessages" sub-bucket. If it was a rollback message, the result is stored in the
+	// "rollbackMessages" sub-bucket. The content of these buckets is never deleted. The key in
+	// the bucket (or more precisely, in the sub-buckets) represents the message ID, while the
+	// value stores the contents of the `BridgeMessageResult` event (more precisely, its struct
+	// representation in Go).
 	executedMessages = []byte("executed")
 
-	// errNotEnoughBridgeEvents error message
-	errNotEnoughBridgeEvents = errors.New("there is either a gap or not enough bridge events")
-	// errNoBridgeBatchForBridgeEvent error message
-	errNoBridgeBatchForBridgeEvent = errors.New("no bridge batch found for given bridge message events")
+	// unexecutedBatches (int. name "unexecuted") is a bucket that contains all I2E batches that
+	// have not yet been executed on the external chain. A batch is written to this bucket upon
+	// commit to BridgeStorage (i.e., when a `NewBatch` event occurs), and removed once all its
+	// messages have been executed on the external chain. The key in this bucket represents the
+	// base hash of the batch, while the value is the serial number of the committed batch. Both
+	// of them, the base hash and the serial number, can be used to uniquely identify any batch,
+	// but on different levels (since base hash doesn't include threshold and commit counter, it
+	// is the same for the original batch and all its retry versions).
+	//
+	// Base hash represents a hash of three concatenated encoded batch metadata fields:
+	// 1. source chain ID,
+	// 2. destination chain ID,
+	// 3. list of message IDs being bridged (note: in current implementation, complete messages
+	// are used instead of IDs).
+	unexecutedBatches = []byte("unexecuted")
 )
 
 // BridgeBatchVoteConsensusData encapsulates sender identifier and its signature
@@ -58,61 +103,79 @@ type BridgeBatchVote struct {
 }
 
 type BridgeManagerStore struct {
-	db              *bolt.DB
-	chainIDs        []uint64
-	internalChainID uint64
+	db               *bolt.DB
+	externalChainIDs []uint64
+	internalChainID  uint64
 }
 
-func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint64,
-	internalChainID uint64) (*BridgeManagerStore, error) {
-	var err error
-
-	store := &BridgeManagerStore{db: db, chainIDs: externalChainsIDs, internalChainID: internalChainID}
-
+// newBridgeManagerStore takes an instance of the bolt database and creates a complete bucket
+// tree structure within it necessary for the proper functioning of the bridging process. For
+// a detailed description of this structure, see the comment within the function itself. The
+// IDs of all external chains to which the internal (Blade) chain realizes bridging should be
+// provided through the externalChainsIDs argument.
+func newBridgeManagerStore(
+	db *bolt.DB,
+	externalChainsIDs []uint64,
+	internalChainID uint64,
+	dbTx *bolt.Tx) (*BridgeManagerStore, error) {
+	// The bucket tree structure intended for manipulating messages is organized as follows (by
+	// levels):
+	//
+	// 1. Root level ("bridgeMessages" bucket)
+	//
+	// 2. Source chain level:
+	//    - Since each chain can be source of the bridging, we create one bucket for each chain
+	//      participating in the bridging process.
+	//    - Bucket names are the chain IDs.
+	//    - Example: With internal (Blade) chain ID 100 and external chain IDs 1, 2, 3, we will
+	//      have four buckets named "100", "1", "2", and "3", respectively.
+	//    - In the context of a bridge message, this represents the ID of the chain from which
+	//      the message originates.
+	//
+	// 3. Destination chain level:
+	//    - If the internal chain is at level 2, we create a bucket for each external chain.
+	//    - If the external chain is at level 2, we create a single bucket for internal chain.
+	//    - This structure is logical since the internal chain can bridge to any external chain,
+	//      but external chains can only bridge to the internal chain.
+	//    - Example: With internal (Blade) chain at level 2, we will have three buckets named
+	//      "1", "2" and "3" at this level. With external chain at level 2, we will have only
+	//      one bucket named "100" at this level.
+	//    - In the context of a bridge message, this represents the ID of the chain to which the
+	//      message is going (that is, to which the message is being relayed).
+	//
+	// 4. Message state level:
+	//    - Each bucket from level 3 contains three buckets:
+	//      1. "ordinaryMessages",
+	//      2. "rollbackMessages", and
+	//      3. "executedMessages"
+	//
+	// 5. Executed messages sublevel:
+	//    - The "executedMessages" bucket from level 4 contains two additional buckets:
+	//      1. "ordinaryMessages", and
+	//      2. "rollbackMessages"
 	initFn := func(tx *bolt.Tx) error {
-		var (
-			bridgeMessageBucket     *bolt.Bucket
-			bridgeBatchesBucket     *bolt.Bucket
-			epochBucket             *bolt.Bucket
-			unexecutedBatchesBucket *bolt.Bucket
-		)
-
-		if bridgeMessageBucket, err = tx.CreateBucketIfNotExists(bridgeMessageEventsBucket); err != nil {
-			return fmt.Errorf("failed to create bucket=%s: %w", string(bridgeMessageEventsBucket), err)
+		// First (root) level bucket.
+		bridgeMessagesBucket, err := tx.CreateBucketIfNotExists(bridgeMessages)
+		if err != nil {
+			return fmt.Errorf("failed to create root bucket for bridge messages: %w", err)
 		}
 
-		if bridgeBatchesBucket, err = tx.CreateBucketIfNotExists(bridgeBatchBucket); err != nil {
-			return fmt.Errorf("failed to create bucket=%s: %w", string(bridgeBatchBucket), err)
+		unexecutedBatchesBucket, err := tx.CreateBucketIfNotExists(unexecutedBatches)
+		if err != nil {
+			return fmt.Errorf("failed to create root bucket for unexecuted batches: %w", err)
 		}
 
-		if epochBucket, err = tx.CreateBucketIfNotExists(epochsBucket); err != nil {
-			return fmt.Errorf("failed to create bucket=%s: %w", string(epochsBucket), err)
+		internalIDBytes := common.EncodeUint64ToBytes(internalChainID)
+
+		// Second (source chain) level bucket.
+		internalChainBucket, err := bridgeMessagesBucket.CreateBucketIfNotExists(internalIDBytes)
+		if err != nil {
+			return fmt.Errorf("failed to create (source) internal chain bucket: %w", err)
 		}
 
-		if unexecutedBatchesBucket, err = tx.CreateBucketIfNotExists(unexecutedBatches); err != nil {
-			return fmt.Errorf("failed to create bucket=%s: %w", string(unexecutedBatches), err)
-		}
-
-		// because we have multiple chains that can generate same events
-		// we need to create bridge message bucket for each pair of internal and external chains
-		createBucketsAndReturnBridgeMessageBucket := func(chainIDBytes []byte) (*bolt.Bucket, error) {
-			bridgeMessageChainIDBucket, err := bridgeMessageBucket.CreateBucketIfNotExists(chainIDBytes)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create bucket chainID=%s: %w", string(bridgeMessageEventsBucket), err)
-			}
-
-			if _, err := bridgeBatchesBucket.CreateBucketIfNotExists(chainIDBytes); err != nil {
-				return nil, fmt.Errorf("failed to create bucket chainID=%s: %w", string(bridgeBatchBucket), err)
-			}
-
-			if _, err := epochBucket.CreateBucketIfNotExists(chainIDBytes); err != nil {
-				return nil, fmt.Errorf("failed to create bucket chainID=%s: %w", string(epochsBucket), err)
-			}
-
-			return bridgeMessageChainIDBucket, nil
-		}
-
-		createOrdinaryAndRollbackBucket := func(bucket *bolt.Bucket) error {
+		// Function to create buckets for ordinary and rollback messages on the fourth and fifth
+		// level within bucket tree structure.
+		createOrdinaryAndRollbackBuckets := func(bucket *bolt.Bucket) error {
 			if _, err := bucket.CreateBucketIfNotExists(ordinaryMessages); err != nil {
 				return fmt.Errorf("failed to create bucket for ordinary messages: %w", err)
 			}
@@ -124,48 +187,52 @@ func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint6
 			return nil
 		}
 
-		internalChainIDBytes := common.EncodeUint64ToBytes(internalChainID)
+		for _, externalChainID := range externalChainsIDs {
+			id := common.EncodeUint64ToBytes(externalChainID)
 
-		internalBridgeMessageBucket, err := createBucketsAndReturnBridgeMessageBucket(internalChainIDBytes)
-		if err != nil {
-			return err
-		}
-
-		for _, chainID := range externalChainsIDs {
-			chainIDBytes := common.EncodeUint64ToBytes(chainID)
-
-			bridgeMessageChainIDBucket, err := createBucketsAndReturnBridgeMessageBucket(chainIDBytes)
+			// Second (source chain) level bucket.
+			externalChainBucket, err := bridgeMessagesBucket.CreateBucketIfNotExists(id)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create (source) external chain (%v) bucket: %w",
+					externalChainID,
+					err)
 			}
 
-			if _, err = unexecutedBatchesBucket.CreateBucketIfNotExists(chainIDBytes); err != nil {
-				return fmt.Errorf("failed to create bucket for unexecuted batches: %w", err)
+			if _, err = unexecutedBatchesBucket.CreateBucketIfNotExists(id); err != nil {
+				return fmt.Errorf("failed to create unexecuted batches bucket for chain %v: %w",
+					externalChainID,
+					err)
 			}
 
+			// Third (destination chain) level buckets.
 			var buckets [2]*bolt.Bucket
 
-			// create bucket for internal chainID in external chainID bucket
-			if buckets[0], err = bridgeMessageChainIDBucket.CreateBucketIfNotExists(internalChainIDBytes); err != nil {
-				return fmt.Errorf("failed to create bucket chainID=%s: %w", string(bridgeMessageEventsBucket), err)
+			buckets[0], err = externalChainBucket.CreateBucketIfNotExists(internalIDBytes)
+			if err != nil {
+				return fmt.Errorf("failed to create (destination) internal chain bucket: %w", err)
 			}
 
-			// create bucket for external chainID in internal chainID bucket
-			if buckets[1], err = internalBridgeMessageBucket.CreateBucketIfNotExists(chainIDBytes); err != nil {
-				return fmt.Errorf("failed to create bucket chainID=%s: %w", string(bridgeMessageEventsBucket), err)
+			buckets[1], err = internalChainBucket.CreateBucketIfNotExists(id)
+			if err != nil {
+				return fmt.Errorf("failed to create (destination) external chain (%v) bucket: %w",
+					externalChainID,
+					err)
 			}
 
 			for _, bucket := range buckets {
-				if err := createOrdinaryAndRollbackBucket(bucket); err != nil {
+				// Fourth (message state) level bucket.
+				if err := createOrdinaryAndRollbackBuckets(bucket); err != nil {
 					return err
 				}
 
-				executedBucket, err := bucket.CreateBucketIfNotExists(executedMessages)
+				// Fourth (message state) level bucket.
+				executedMessagesBucket, err := bucket.CreateBucketIfNotExists(executedMessages)
 				if err != nil {
-					return fmt.Errorf("failed to create buckets for executed messages: %w", err)
+					return fmt.Errorf("failed to create bucket for executed messages: %w", err)
 				}
 
-				if err := createOrdinaryAndRollbackBucket(executedBucket); err != nil {
+				// Fifth (executed messages) level bucket.
+				if err := createOrdinaryAndRollbackBuckets(executedMessagesBucket); err != nil {
 					return err
 				}
 			}
@@ -174,16 +241,29 @@ func newBridgeManagerStore(db *bolt.DB, dbTx *bolt.Tx, externalChainsIDs []uint6
 		return nil
 	}
 
+	var (
+		err   error
+		store *BridgeManagerStore
+	)
+
 	if dbTx == nil {
 		err = db.Update(initFn)
 	} else {
 		err = initFn(dbTx)
 	}
 
+	if err == nil {
+		store = &BridgeManagerStore{
+			db:               db,
+			externalChainIDs: externalChainsIDs,
+			internalChainID:  internalChainID,
+		}
+	}
+
 	return store, err
 }
 
-func (bms *BridgeManagerStore) BeginDBTransaction(isWriteTx bool) (*bolt.Tx, error) {
+func (bms *BridgeManagerStore) beginDBTransaction(isWriteTx bool) (*bolt.Tx, error) {
 	return bms.db.Begin(isWriteTx)
 }
 
@@ -196,7 +276,7 @@ func (bms *BridgeManagerStore) insertBridgeMessageEvent(event *contractsapi.Brid
 			return err
 		}
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(event.SourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(event.DestinationChainID.Uint64()))
 
@@ -219,7 +299,7 @@ func (bms *BridgeManagerStore) removeBridgeMessageEvent(messageID, sourceChainID
 	removeFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(messageID.Uint64())
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(sourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(destinationChainID.Uint64()))
 
@@ -244,7 +324,7 @@ func (bms *BridgeManagerStore) getBridgeMessageEvent(messageID, sourceChainID, d
 	getFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(messageID.Uint64())
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(sourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(destinationChainID.Uint64()))
 
@@ -288,7 +368,7 @@ func (bms *BridgeManagerStore) isBridgeMessageKnown(message *contractsapi.Bridge
 	getFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(message.ID.Uint64())
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(message.SourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(message.DestinationChainID.Uint64()))
 
@@ -322,7 +402,7 @@ func (bms *BridgeManagerStore) isBridgeMessageExecuted(message *contractsapi.Bri
 	getFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(message.ID.Uint64())
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(message.SourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(message.DestinationChainID.Uint64())).
 			Bucket(executedMessages)
@@ -431,7 +511,7 @@ func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(result *contractsa
 			return err
 		}
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(result.SourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(result.DestinationChainID.Uint64())).
 			Bucket(executedMessages)
@@ -457,7 +537,7 @@ func (bms *BridgeManagerStore) getBridgeMessageResult(message *contractsapi.Brid
 	getFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(message.ID.Uint64())
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(message.SourceChainID.Uint64())).
 			Bucket(common.EncodeUint64ToBytes(message.DestinationChainID.Uint64())).
 			Bucket(executedMessages)
@@ -496,97 +576,6 @@ func (bms *BridgeManagerStore) getBridgeMessageResult(message *contractsapi.Brid
 	return result, nil
 }
 
-// removeBridgeEvents removes bridge events and their proofs from the buckets in db
-func (bms *BridgeManagerStore) removeBridgeEvents(
-	bridgeMessageResult contractsapi.BridgeMessageResultEvent, dbTx *bolt.Tx) error {
-	insertFn := func(tx *bolt.Tx) error {
-		eventsBucket := tx.Bucket(bridgeMessageEventsBucket).
-			Bucket(common.EncodeUint64ToBytes(bridgeMessageResult.SourceChainID.Uint64())).
-			Bucket(common.EncodeUint64ToBytes(bridgeMessageResult.DestinationChainID.Uint64()))
-
-		bridgeMessageID := bridgeMessageResult.ID.Uint64()
-		bridgeMessageEventIDKey := common.EncodeUint64ToBytes(bridgeMessageID)
-
-		if err := eventsBucket.Delete(bridgeMessageEventIDKey); err != nil {
-			return fmt.Errorf("failed to remove bridge message event (ID=%d): %w", bridgeMessageID, err)
-		}
-
-		return nil
-	}
-
-	if dbTx == nil {
-		return bms.db.Update(func(tx *bolt.Tx) error {
-			return insertFn(tx)
-		})
-	}
-
-	return insertFn(dbTx)
-}
-
-func (bms *BridgeManagerStore) list(internalChainID uint64) ([]*contractsapi.BridgeMessage, error) {
-	messages := []*contractsapi.BridgeMessage{}
-
-	icid := common.EncodeUint64ToBytes(internalChainID)
-
-	getMsgsFn := func(_, v []byte, isRollback bool) error {
-		var event *contractsapi.BridgeMsgEvent
-		if err := json.Unmarshal(v, &event); err != nil {
-			return err
-		}
-
-		message := &contractsapi.BridgeMessage{
-			ID:                 event.ID,
-			SourceChainID:      event.SourceChainID,
-			DestinationChainID: event.DestinationChainID,
-			Sender:             event.Sender,
-			Receiver:           event.Receiver,
-			Payload:            event.Data,
-			IsRollback:         isRollback,
-		}
-
-		messages = append(messages, message)
-
-		return nil
-	}
-
-	ordMsgsFn := func(k, v []byte) error {
-		return getMsgsFn(k, v, false)
-	}
-
-	rollMsgsFn := func(k, v []byte) error {
-		return getMsgsFn(k, v, true)
-	}
-
-	err := bms.db.View(func(tx *bolt.Tx) error {
-		bridgeMessageBucket := tx.Bucket(bridgeMessageEventsBucket)
-
-		var err error
-
-		for _, externalChainID := range bms.chainIDs {
-			ecid := common.EncodeUint64ToBytes(externalChainID)
-			if err = bridgeMessageBucket.Bucket(icid).Bucket(ecid).Bucket(ordinaryMessages).ForEach(ordMsgsFn); err != nil {
-				break
-			}
-
-			if err = bridgeMessageBucket.Bucket(icid).Bucket(ecid).Bucket(rollbackMessages).ForEach(rollMsgsFn); err != nil {
-				break
-			}
-
-			if err = bridgeMessageBucket.Bucket(ecid).Bucket(icid).Bucket(ordinaryMessages).ForEach(ordMsgsFn); err != nil {
-				break
-			}
-
-			if err = bridgeMessageBucket.Bucket(icid).Bucket(ecid).Bucket(rollbackMessages).ForEach(rollMsgsFn); err != nil {
-				break
-			}
-		}
-
-		return err
-	})
-
-	return messages, err
-}
-
 func (bms *BridgeManagerStore) getBridgeMessages(
 	fromIndex,
 	limit,
@@ -608,7 +597,7 @@ func (bms *BridgeManagerStore) getBridgeMessages(
 	getFn := func(tx *bolt.Tx) error {
 		var taken uint64
 
-		bucket := tx.Bucket(bridgeMessageEventsBucket).
+		bucket := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(sid)).
 			Bucket(common.EncodeUint64ToBytes(did)).
 			Bucket(ordinaryMessages)
@@ -648,7 +637,7 @@ func (bms *BridgeManagerStore) getBridgeMessages(
 
 		var toRemove []*big.Int
 
-		err := tx.Bucket(bridgeMessageEventsBucket).
+		err := tx.Bucket(bridgeMessages).
 			Bucket(common.EncodeUint64ToBytes(sid)).
 			Bucket(common.EncodeUint64ToBytes(did)).
 			Bucket(rollbackMessages).ForEach(func(k, v []byte) error {
@@ -702,7 +691,7 @@ func (bms *BridgeManagerStore) getBridgeMessages(
 		for _, id := range toRemove {
 			id := common.EncodeUint64ToBytes(id.Uint64())
 
-			if err := tx.Bucket(bridgeMessageEventsBucket).
+			if err := tx.Bucket(bridgeMessages).
 				Bucket(common.EncodeUint64ToBytes(sid)).
 				Bucket(common.EncodeUint64ToBytes(did)).
 				Bucket(rollbackMessages).Delete(id); err != nil {
@@ -728,256 +717,4 @@ func (bms *BridgeManagerStore) getBridgeMessages(
 	}
 
 	return messages, numOfOrdinaryMsgs, err
-}
-
-// getBridgeBatchForBridgeEvents returns the bridgeBatch that contains given bridge event if it exists
-func (bms *BridgeManagerStore) getBridgeBatchForBridgeEvents(
-	bridgeMessageID,
-	chainID uint64) (*BridgeBatchSigned, error) {
-	var signedBridgeBatch *BridgeBatchSigned
-
-	err := bms.db.View(func(tx *bolt.Tx) error {
-		c := tx.Bucket(bridgeBatchBucket).Bucket(common.EncodeUint64ToBytes(chainID)).Cursor()
-
-		k, v := c.Seek(common.EncodeUint64ToBytes(bridgeMessageID))
-		if k == nil {
-			return errNoBridgeBatchForBridgeEvent
-		}
-
-		if err := json.Unmarshal(v, &signedBridgeBatch); err != nil {
-			return err
-		}
-
-		if !signedBridgeBatch.ContainsBridgeMessage(bridgeMessageID) {
-			return errNoBridgeBatchForBridgeEvent
-		}
-
-		return nil
-	})
-
-	return signedBridgeBatch, err
-}
-
-// insertBridgeBatchMessage inserts signed batch to db
-func (bms *BridgeManagerStore) insertBridgeBatchMessage(signedBridgeBatch *BridgeBatchSigned,
-	dbTx *bolt.Tx) error {
-	insertFn := func(tx *bolt.Tx) error {
-		raw, err := json.Marshal(signedBridgeBatch)
-		if err != nil {
-			return err
-		}
-
-		if err := tx.Bucket(bridgeBatchBucket).
-			Bucket(common.EncodeUint64ToBytes(
-				signedBridgeBatch.BridgeMessageBatch.SourceChainID.Uint64())).Put(
-			common.EncodeUint64ToBytes(
-				signedBridgeBatch.BridgeMessageBatch.Messages[len(signedBridgeBatch.Messages)-1].
-					ID.Uint64()), raw); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	if dbTx == nil {
-		return bms.db.Update(func(tx *bolt.Tx) error {
-			return insertFn(tx)
-		})
-	}
-
-	return insertFn(dbTx)
-}
-
-// insertConsensusData inserts given batch consensus data to corresponding bucket of given epoch
-func (bms *BridgeManagerStore) insertConsensusData(epoch uint64, key []byte,
-	vote *BridgeBatchVoteConsensusData, dbTx *bolt.Tx, sourceChainID uint64) (int, error) {
-	var (
-		numOfSignatures int
-		err             error
-	)
-
-	insertFn := func(tx *bolt.Tx) error {
-		signatures, err := bms.getMessageVotesLocked(tx, epoch, key, sourceChainID)
-		if err != nil {
-			return err
-		}
-
-		// check if the signature has already being included
-		for _, sigs := range signatures {
-			if sigs.Sender == vote.Sender {
-				return nil
-			}
-		}
-
-		if signatures == nil {
-			signatures = []*BridgeBatchVoteConsensusData{vote}
-		} else {
-			signatures = append(signatures, vote)
-		}
-
-		raw, err := json.Marshal(signatures)
-		if err != nil {
-			return err
-		}
-
-		bucket, err := getNestedBucketInEpoch(tx, epoch, messageVotesBucket, sourceChainID)
-		if err != nil {
-			return err
-		}
-
-		numOfSignatures = len(signatures)
-
-		return bucket.Put(key, raw)
-	}
-
-	if dbTx == nil {
-		err = bms.db.Update(func(tx *bolt.Tx) error {
-			return insertFn(tx)
-		})
-	} else {
-		err = insertFn(dbTx)
-	}
-
-	return numOfSignatures, err
-}
-
-// getMessageVotes gets all signatures from db associated with given epoch and hash
-func (bms *BridgeManagerStore) getMessageVotes(
-	epoch uint64,
-	hash []byte,
-	sourceChainID uint64) ([]*BridgeBatchVoteConsensusData, error) {
-	var signatures []*BridgeBatchVoteConsensusData
-
-	err := bms.db.View(func(tx *bolt.Tx) error {
-		res, err := bms.getMessageVotesLocked(tx, epoch, hash, sourceChainID)
-		if err != nil {
-			return err
-		}
-
-		signatures = res
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return signatures, nil
-}
-
-// getMessageVotesLocked gets all signatures from db associated with given epoch and hash
-func (bms *BridgeManagerStore) getMessageVotesLocked(tx *bolt.Tx, epoch uint64,
-	hash []byte, sourceChainID uint64) ([]*BridgeBatchVoteConsensusData, error) {
-	bucket, err := getNestedBucketInEpoch(tx, epoch, messageVotesBucket, sourceChainID)
-	if err != nil {
-		return nil, err
-	}
-
-	v := bucket.Get(hash)
-	if v == nil {
-		return nil, nil
-	}
-
-	var signatures []*BridgeBatchVoteConsensusData
-	if err := json.Unmarshal(v, &signatures); err != nil {
-		return nil, err
-	}
-
-	return signatures, nil
-}
-
-// getNestedBucketInEpoch returns a nested (child) bucket from db associated with given epoch
-func getNestedBucketInEpoch(tx *bolt.Tx, epoch uint64, bucketKey []byte, chainID uint64) (*bolt.Bucket, error) {
-	epochBucket, err := getEpochBucket(tx, epoch, chainID)
-	if err != nil {
-		return nil, err
-	}
-
-	bucket := epochBucket.Bucket(bucketKey)
-	if bucket == nil {
-		return nil, fmt.Errorf("could not find %v bucket for epoch: %v", string(bucketKey), epoch)
-	}
-
-	return bucket, nil
-}
-
-// getEpochBucket returns bucket from db associated with given epoch
-func getEpochBucket(tx *bolt.Tx, epoch uint64, chainID uint64) (*bolt.Bucket, error) {
-	epochBucket := tx.Bucket(epochsBucket)
-	if epochBucket == nil {
-		return nil, fmt.Errorf("could not find epoch bucket")
-	}
-
-	epochBucket = epochBucket.Bucket(common.EncodeUint64ToBytes(chainID))
-	if epochBucket == nil {
-		return nil, fmt.Errorf("could not find epoch bucket for chain %d", chainID)
-	}
-
-	epochBucket = epochBucket.Bucket(common.EncodeUint64ToBytes(epoch))
-	if epochBucket == nil {
-		return nil, fmt.Errorf("could not find bucket for epoch: %v", epoch)
-	}
-
-	return epochBucket, nil
-}
-
-// insertEpoch inserts a new epoch to db with its meta data
-func (bms *BridgeManagerStore) insertEpoch(epoch uint64, dbTx *bolt.Tx, chainID uint64) error {
-	insertFn := func(tx *bolt.Tx) error {
-		chainIDBucket, err := tx.Bucket(epochsBucket).CreateBucketIfNotExists(common.EncodeUint64ToBytes(chainID))
-		if err != nil {
-			return err
-		}
-
-		epochBucket, err := chainIDBucket.CreateBucketIfNotExists(common.EncodeUint64ToBytes(epoch))
-		if err != nil {
-			return err
-		}
-
-		_, err = epochBucket.CreateBucketIfNotExists(messageVotesBucket)
-		if err != nil {
-			return err
-		}
-
-		return err
-	}
-
-	if dbTx == nil {
-		return bms.db.Update(func(tx *bolt.Tx) error {
-			return insertFn(tx)
-		})
-	}
-
-	return insertFn(dbTx)
-}
-
-// cleanEpochsFromDB cleans epoch buckets from db
-func (bms *BridgeManagerStore) cleanEpochsFromDB(dbTx *bolt.Tx) error {
-	cleanFn := func(tx *bolt.Tx) error {
-		if err := tx.DeleteBucket(epochsBucket); err != nil {
-			return err
-		}
-
-		epochBucket, err := tx.CreateBucket(epochsBucket)
-		if err != nil {
-			return err
-		}
-
-		for _, chainID := range bms.chainIDs {
-			if _, err := epochBucket.CreateBucket(common.EncodeUint64ToBytes(chainID)); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
-	if dbTx == nil {
-		return bms.db.Update(func(tx *bolt.Tx) error {
-			return cleanFn(tx)
-		})
-	}
-
-	return cleanFn(dbTx)
 }

--- a/consensus/polybft/bridge/state_store_bridge_message.go
+++ b/consensus/polybft/bridge/state_store_bridge_message.go
@@ -81,27 +81,29 @@ var (
 	unexecutedBatches = []byte("unexecuted")
 )
 
-// BridgeBatchVoteConsensusData encapsulates sender identifier and its signature
+// BridgeBatchVoteConsensusData encapsulates sender identifier and its signature.
 type BridgeBatchVoteConsensusData struct {
-	// Signer of the vote
+	// Signer of the vote.
 	Sender string
-	// Signature of the message
+	// Signature of the message.
 	Signature []byte
 }
 
-// BridgeBatchVote represents the payload which is gossiped across the network
+// BridgeBatchVote represents the payload which is gossiped across the network.
 type BridgeBatchVote struct {
 	*BridgeBatchVoteConsensusData
-	// Hash is encoded data
+	// Hash represents the full hash of the bridge batch. This is the subject of the signing.
 	Hash []byte
-	// Number of epoch
+	// EpochNumber denotes the epoch in which the vote was produced.
 	EpochNumber uint64
-	// SourceChainID from bridge batch
+	// SourceChainID represents the ID of the originating chain.
 	SourceChainID uint64
-	// DestinationChainID from bridge batch
+	// DestinationChainID represents the ID of the destination chain.
 	DestinationChainID uint64
 }
 
+// BridgeManagerStore is a wrapper around boltDB that provides all the necessary methods for the
+// bridging "cold" storage logic.
 type BridgeManagerStore struct {
 	db               *bolt.DB
 	externalChainIDs []uint64
@@ -267,8 +269,9 @@ func (bms *BridgeManagerStore) beginDBTransaction(isWriteTx bool) (*bolt.Tx, err
 	return bms.db.Begin(isWriteTx)
 }
 
-// insertBridgeMessageEvent inserts a new bridge message event to state event bucket in db
-func (bms *BridgeManagerStore) insertBridgeMessageEvent(event *contractsapi.BridgeMsgEvent, isRollback bool,
+func (bms *BridgeManagerStore) insertBridgeMessageEvent(
+	event *contractsapi.BridgeMsgEvent,
+	isRollback bool,
 	dbTx *bolt.Tx) error {
 	insertFn := func(tx *bolt.Tx) error {
 		raw, err := json.Marshal(event)
@@ -281,10 +284,12 @@ func (bms *BridgeManagerStore) insertBridgeMessageEvent(event *contractsapi.Brid
 			Bucket(common.EncodeUint64ToBytes(event.DestinationChainID.Uint64()))
 
 		if isRollback {
-			return bucket.Bucket(rollbackMessages).Put(common.EncodeUint64ToBytes(event.ID.Uint64()), raw)
+			return bucket.Bucket(rollbackMessages).
+				Put(common.EncodeUint64ToBytes(event.ID.Uint64()), raw)
 		}
 
-		return bucket.Bucket(ordinaryMessages).Put(common.EncodeUint64ToBytes(event.ID.Uint64()), raw)
+		return bucket.Bucket(ordinaryMessages).
+			Put(common.EncodeUint64ToBytes(event.ID.Uint64()), raw)
 	}
 
 	if dbTx == nil {
@@ -294,8 +299,12 @@ func (bms *BridgeManagerStore) insertBridgeMessageEvent(event *contractsapi.Brid
 	return insertFn(dbTx)
 }
 
-func (bms *BridgeManagerStore) removeBridgeMessageEvent(messageID, sourceChainID, destinationChainID *big.Int,
-	isRollback bool, dbTx *bolt.Tx) error {
+func (bms *BridgeManagerStore) removeBridgeMessageEvent(
+	messageID,
+	sourceChainID,
+	destinationChainID *big.Int,
+	isRollback bool,
+	dbTx *bolt.Tx) error {
 	removeFn := func(tx *bolt.Tx) error {
 		id := common.EncodeUint64ToBytes(messageID.Uint64())
 
@@ -317,8 +326,12 @@ func (bms *BridgeManagerStore) removeBridgeMessageEvent(messageID, sourceChainID
 	return removeFn(dbTx)
 }
 
-func (bms *BridgeManagerStore) getBridgeMessageEvent(messageID, sourceChainID, destinationChainID *big.Int,
-	isRollback bool, dbTx *bolt.Tx) (*contractsapi.BridgeMsgEvent, error) {
+func (bms *BridgeManagerStore) getBridgeMessageEvent(
+	messageID,
+	sourceChainID,
+	destinationChainID *big.Int,
+	isRollback bool,
+	dbTx *bolt.Tx) (*contractsapi.BridgeMsgEvent, error) {
 	var message *contractsapi.BridgeMsgEvent
 
 	getFn := func(tx *bolt.Tx) error {
@@ -362,7 +375,9 @@ func (bms *BridgeManagerStore) getBridgeMessageEvent(messageID, sourceChainID, d
 	return message, nil
 }
 
-func (bms *BridgeManagerStore) isBridgeMessageKnown(message *contractsapi.BridgeMessage, dbTx *bolt.Tx) bool {
+func (bms *BridgeManagerStore) isBridgeMessageKnown(
+	message *contractsapi.BridgeMessage,
+	dbTx *bolt.Tx) bool {
 	var known bool
 
 	getFn := func(tx *bolt.Tx) error {
@@ -396,7 +411,9 @@ func (bms *BridgeManagerStore) isBridgeMessageKnown(message *contractsapi.Bridge
 	return known
 }
 
-func (bms *BridgeManagerStore) isBridgeMessageExecuted(message *contractsapi.BridgeMessage, dbTx *bolt.Tx) bool {
+func (bms *BridgeManagerStore) isBridgeMessageExecuted(
+	message *contractsapi.BridgeMessage,
+	dbTx *bolt.Tx) bool {
 	var executed bool
 
 	getFn := func(tx *bolt.Tx) error {
@@ -503,7 +520,8 @@ func (bms *BridgeManagerStore) removeUnexecutedBatch(
 	return removeFn(dbTx)
 }
 
-func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(result *contractsapi.BridgeMessageResultEvent,
+func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(
+	result *contractsapi.BridgeMessageResultEvent,
 	dbTx *bolt.Tx) error {
 	insertFn := func(tx *bolt.Tx) error {
 		raw, err := json.Marshal(result)
@@ -517,10 +535,12 @@ func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(result *contractsa
 			Bucket(executedMessages)
 
 		if result.IsRollback {
-			return bucket.Bucket(rollbackMessages).Put(common.EncodeUint64ToBytes(result.ID.Uint64()), raw)
+			return bucket.Bucket(rollbackMessages).
+				Put(common.EncodeUint64ToBytes(result.ID.Uint64()), raw)
 		}
 
-		return bucket.Bucket(ordinaryMessages).Put(common.EncodeUint64ToBytes(result.ID.Uint64()), raw)
+		return bucket.Bucket(ordinaryMessages).
+			Put(common.EncodeUint64ToBytes(result.ID.Uint64()), raw)
 	}
 
 	if dbTx == nil {
@@ -530,7 +550,8 @@ func (bms *BridgeManagerStore) insertBridgeMessageResultEvent(result *contractsa
 	return insertFn(dbTx)
 }
 
-func (bms *BridgeManagerStore) getBridgeMessageResult(message *contractsapi.BridgeMessage,
+func (bms *BridgeManagerStore) getBridgeMessageResult(
+	message *contractsapi.BridgeMessage,
 	dbTx *bolt.Tx) (*contractsapi.BridgeMessageResultEvent, error) {
 	var result *contractsapi.BridgeMessageResultEvent
 

--- a/consensus/polybft/bridge/state_store_bridge_message_test.go
+++ b/consensus/polybft/bridge/state_store_bridge_message_test.go
@@ -2,7 +2,6 @@ package bridge
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -87,50 +86,6 @@ func TestState_getBridgeEventsForBridgeBatch(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, maxNumberOfBatchEvents, len(messages))
 	})
-}
-
-func TestState_getBridgeBatchForBridgeEvents(t *testing.T) {
-	const (
-		numOfBridgeBatches = 10
-	)
-
-	state := newTestState(t)
-
-	insertTestBridgeBatches(t, state, numOfBridgeBatches)
-
-	var cases = []struct {
-		bridgeMessageID uint64
-		hasBatch        bool
-	}{
-		{1, true},
-		{10, true},
-		{11, true},
-		{7, true},
-		{999, false},
-		{121, false},
-		{99, true},
-		{101, true},
-		{111, false},
-		{75, true},
-		{5, true},
-		{102, true},
-		{211, false},
-		{21, true},
-		{30, true},
-		{81, true},
-		{90, true},
-	}
-
-	for _, c := range cases {
-		signedBridgeBatch, err := state.getBridgeBatchForBridgeEvents(c.bridgeMessageID, 1)
-
-		if c.hasBatch {
-			require.NoError(t, err, fmt.Sprintf("bridge event %v", c.bridgeMessageID))
-			require.Equal(t, c.hasBatch, signedBridgeBatch.ContainsBridgeMessage(c.bridgeMessageID))
-		} else {
-			require.ErrorIs(t, errNoBridgeBatchForBridgeEvent, err)
-		}
-	}
 }
 
 func TestState_GetNestedBucketInEpoch(t *testing.T) {
@@ -937,13 +892,4 @@ func Test_getUnexecutedBatches(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 1, len(ids))
 	require.EqualValues(t, 35, ids[0])
-}
-
-func insertTestBridgeBatches(t *testing.T, state *BridgeManagerStore, numberOfBatches uint64) {
-	t.Helper()
-
-	for i := uint64(0); i <= numberOfBatches; i++ {
-		signedBridgeBatch := CreateTestBridgeBatchMessage(t, 10, 10*i)
-		require.NoError(t, state.insertBridgeBatchMessage(signedBridgeBatch, nil))
-	}
 }

--- a/consensus/polybft/bridge/state_store_bridge_message_test.go
+++ b/consensus/polybft/bridge/state_store_bridge_message_test.go
@@ -1,143 +1,135 @@
 package bridge
 
 import (
-	"bytes"
 	"math/big"
 	"testing"
 
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	systemstate "github.com/0xPolygon/polygon-edge/consensus/polybft/system_state"
-	"github.com/0xPolygon/polygon-edge/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.etcd.io/bbolt"
 )
 
-func TestState_InsertEvent(t *testing.T) {
-	t.Parallel()
+func Test_BridgeMessageResult(t *testing.T) {
+	s := newTestState(t)
 
-	state := newTestState(t)
-	event := &contractsapi.BridgeMsgEvent{
-		ID:                 big.NewInt(1),
-		Sender:             types.Address{},
-		Receiver:           types.Address{},
-		Data:               []byte{},
+	// This test checks the correctness of the following BridgeManagerStore methods:
+	// 1. (*BridgeManagerStore).insertBridgeMessageResultEvent
+	// 2. (*BridgeManagerStore).getBridgeMessageResult
+	// 3. (*BridgeManagerStore).isBridgeMessageExecuted
+
+	ordinaryMessage := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(20),
 		SourceChainID:      big.NewInt(100),
 		DestinationChainID: big.NewInt(1),
+		IsRollback:         false,
 	}
 
-	err := state.insertBridgeMessageEvent(event, false, nil)
-	assert.NoError(t, err)
+	rollbackMessage := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(80),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		IsRollback:         true,
+	}
 
-	events, err := state.list(100)
-	assert.NoError(t, err)
-	assert.Len(t, events, 1)
+	ordinaryResult := &contractsapi.BridgeMessageResultEvent{
+		ID:                 big.NewInt(20),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		IsRollback:         false,
+	}
+
+	rollbackResult := &contractsapi.BridgeMessageResultEvent{
+		ID:                 big.NewInt(80),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		IsRollback:         true,
+	}
+
+	require.NoError(t, s.insertBridgeMessageResultEvent(ordinaryResult, nil))
+	require.NoError(t, s.insertBridgeMessageResultEvent(rollbackResult, nil))
+
+	res, err := s.getBridgeMessageResult(ordinaryMessage, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, big.NewInt(20), res.ID)
+	require.False(t, res.IsRollback)
+	require.True(t, s.isBridgeMessageExecuted(ordinaryMessage, nil))
+
+	res, err = s.getBridgeMessageResult(rollbackMessage, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, big.NewInt(80), res.ID)
+	require.True(t, res.IsRollback)
+	require.True(t, s.isBridgeMessageExecuted(rollbackMessage, nil))
+
+	require.False(t, s.isBridgeMessageExecuted(&contractsapi.BridgeMessage{
+		ID:                 big.NewInt(1),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		IsRollback:         true,
+	}, nil))
+
+	require.False(t, s.isBridgeMessageExecuted(&contractsapi.BridgeMessage{
+		ID:                 big.NewInt(1),
+		SourceChainID:      big.NewInt(100),
+		DestinationChainID: big.NewInt(1),
+		IsRollback:         false,
+	}, nil))
 }
 
-func TestState_Insert_And_Get_MessageVotes(t *testing.T) {
-	t.Parallel()
+func Test_BridgeMessageEvent(t *testing.T) {
+	s := newTestState(t)
 
-	state := newTestState(t)
-	epoch := uint64(1)
-	assert.NoError(t, state.insertEpoch(epoch, nil, 0))
+	// This test checks the correctness of the following BridgeManagerStore methods:
+	// 1. (*BridgeManagerStore).insertBridgeMessageEvent
+	// 2. (*BridgeManagerStore).getBridgeMessageEvent
+	// 3. (*BridgeManagerStore).removeBridgeMessageEvent
+	// 4. (*BridgeManagerStore).isBridgeMessageKnown
 
-	hash := []byte{1, 2}
-	_, err := state.insertConsensusData(1, hash, &BridgeBatchVoteConsensusData{
-		Sender:    "NODE_1",
-		Signature: []byte{1, 2},
-	}, nil, 0)
+	sid := big.NewInt(100)
+	did := big.NewInt(1)
 
-	assert.NoError(t, err)
-
-	votes, err := state.getMessageVotes(epoch, hash, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(votes))
-	assert.Equal(t, "NODE_1", votes[0].Sender)
-	assert.True(t, bytes.Equal([]byte{1, 2}, votes[0].Signature))
-}
-
-func TestState_getBridgeEventsForBridgeBatch(t *testing.T) {
-	t.Parallel()
-
-	state := newTestState(t)
-
-	for i := 1; i <= maxNumberOfBatchEvents; i++ {
-		assert.NoError(t, state.insertBridgeMessageEvent(&contractsapi.BridgeMsgEvent{
-			ID:                 big.NewInt(int64(i)),
-			Data:               []byte{1, 2},
-			SourceChainID:      big.NewInt(100),
-			DestinationChainID: big.NewInt(1),
-		}, false, nil))
+	ordinaryEvent := &contractsapi.BridgeMsgEvent{
+		ID:                 big.NewInt(20),
+		SourceChainID:      sid,
+		DestinationChainID: did,
 	}
 
-	t.Run("Return all - forced. Enough messages", func(t *testing.T) {
-		t.Parallel()
-
-		messages, _, err := state.getBridgeMessages(1, maxNumberOfBatchEvents, 100, 1, nil, nil)
-		require.NoError(t, err)
-		require.Equal(t, maxNumberOfBatchEvents, len(messages))
-	})
-
-	t.Run("Return all - forced. Not enough messages", func(t *testing.T) {
-		t.Parallel()
-
-		messages, _, err := state.getBridgeMessages(1, 30, 100, 1, nil, nil)
-		require.NoError(t, err)
-		require.Equal(t, maxNumberOfBatchEvents, len(messages))
-	})
-}
-
-func TestState_GetNestedBucketInEpoch(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name        string
-		epochNumber uint64
-		bucketName  []byte
-		errMsg      string
-	}{
-		{
-			name:        "Not existing inner bucket",
-			epochNumber: 3,
-			bucketName:  []byte("Foo"),
-			errMsg:      "could not find Foo bucket for epoch: 3",
-		},
-		{
-			name:        "Happy path",
-			epochNumber: 5,
-			bucketName:  messageVotesBucket,
-			errMsg:      "",
-		},
+	rollbackEvent := &contractsapi.BridgeMsgEvent{
+		ID:                 big.NewInt(80),
+		SourceChainID:      sid,
+		DestinationChainID: did,
 	}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
-			var (
-				nestedBucket *bbolt.Bucket
-				err          error
-			)
-
-			s := newTestState(t)
-			require.NoError(t, s.insertEpoch(c.epochNumber, nil, 0))
-
-			err = s.db.View(func(tx *bbolt.Tx) error {
-				nestedBucket, err = getNestedBucketInEpoch(tx, c.epochNumber, c.bucketName, 0)
-
-				return err
-			})
-			if c.errMsg != "" {
-				require.ErrorContains(t, err, c.errMsg)
-				require.Nil(t, nestedBucket)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, nestedBucket)
-			}
-		})
+	ordinaryMessage := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(20),
+		SourceChainID:      sid,
+		DestinationChainID: did,
+		IsRollback:         false,
 	}
+
+	rollbackMessage := &contractsapi.BridgeMessage{
+		ID:                 big.NewInt(80),
+		SourceChainID:      sid,
+		DestinationChainID: did,
+		IsRollback:         true,
+	}
+
+	require.NoError(t, s.insertBridgeMessageEvent(ordinaryEvent, false, nil))
+	require.NoError(t, s.insertBridgeMessageEvent(rollbackEvent, true, nil))
+
+	res, err := s.getBridgeMessageEvent(big.NewInt(20), sid, did, false, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, big.NewInt(20), res.ID)
+	require.True(t, s.isBridgeMessageKnown(ordinaryMessage, nil))
+	require.NoError(t, s.removeBridgeMessageEvent(big.NewInt(20), sid, did, false, nil))
+	require.False(t, s.isBridgeMessageKnown(ordinaryMessage, nil))
+
+	res, err = s.getBridgeMessageEvent(big.NewInt(80), sid, did, true, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, big.NewInt(80), res.ID)
+	require.True(t, s.isBridgeMessageKnown(rollbackMessage, nil))
+	require.NoError(t, s.removeBridgeMessageEvent(big.NewInt(80), sid, did, true, nil))
+	require.False(t, s.isBridgeMessageKnown(rollbackMessage, nil))
 }
 
 func Test_getBridgeMessages(t *testing.T) {
@@ -813,8 +805,13 @@ func Test_getBridgeMessages(t *testing.T) {
 	})
 }
 
-func Test_getUnexecutedBatches(t *testing.T) {
+func Test_UnexecutedBatches(t *testing.T) {
 	s := newTestState(t)
+
+	// This test checks the correctness of the following BridgeManagerStore methods:
+	// 1. (*BridgeManagerStore).insertUnexecutedBatch
+	// 2. (*BridgeManagerStore).getUnexecutedBatches
+	// 3. (*BridgeManagerStore).removeUnexecutedBatch
 
 	b1 := PendingBridgeBatch{
 		BridgeMessageBatch: &contractsapi.BridgeMessageBatch{

--- a/e2e-polybft/bridge/helpers_test.go
+++ b/e2e-polybft/bridge/helpers_test.go
@@ -299,8 +299,8 @@ func compareBucketsFromDBs(t *testing.T, db1, db2 *bbolt.DB, sourceChainID, dest
 	// Open read transactions for both databases
 	require.NoError(t, db1.View(func(tx1 *bbolt.Tx) error {
 		require.NoError(t, db2.View(func(tx2 *bbolt.Tx) error {
-			bridgeMessageBucket1 := tx1.Bucket([]byte("bridgeMessageEvents"))
-			bridgeMessageBucket2 := tx2.Bucket([]byte("bridgeMessageEvents"))
+			bridgeMessageBucket1 := tx1.Bucket([]byte("bridgeMessages"))
+			bridgeMessageBucket2 := tx2.Bucket([]byte("bridgeMessages"))
 
 			if bridgeMessageBucket1 == nil || bridgeMessageBucket2 == nil {
 				return fmt.Errorf("bridge message events bucket does not exist")

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"path"
-	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -359,19 +356,4 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	}
 
 	t.Logf("Test passed")
-}
-
-func init() {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
-	parent := filepath.Dir(wd)
-	parent = strings.Trim(parent, "e2e-polybft")
-	wd = filepath.Join(parent, "/artifacts/blade")
-	os.Setenv("EDGE_BINARY", wd)
-	os.Setenv("E2E_TESTS", "true")
-	os.Setenv("E2E_LOGS", "true")
-	os.Setenv("E2E_LOG_LEVEL", "debug")
 }

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -267,7 +267,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 			logs, err := getFilteredLogs((&contractsapi.NewBatchEvent{}).Sig(), 0, latest, internalEndpoint)
 			require.NoError(t, err)
 
-			if len(logs) < 2 {
+			if len(logs) < 4 {
 				return false
 			}
 

--- a/e2e-polybft/bridge/network_test.go
+++ b/e2e-polybft/bridge/network_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -118,9 +121,20 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	deployerKey, err := bridgeHelper.DecodePrivateKey("")
 	require.NoError(t, err)
 
-	// stop relayer until
-	relayer := cluster.BridgeRelayers[0]
-	relayer.Stop()
+	stopRelayerFn := func(startID, endID uint64) {
+		// Minimal time needed for sleep before stopping is sprint time + relayer period = 15s
+		require.NoError(t, cluster.WaitUntil(20*time.Second, 2*time.Second, func() bool {
+			for i := startID; i <= endID; i++ {
+				if !isEventProcessed(t, bridgeCfg.ExternalGatewayAddr, externalChainTxRelayer, i, false) {
+					return false
+				}
+			}
+
+			return true
+		}))
+
+		cluster.BridgeRelayers[0].Stop()
+	}
 
 	var internalERC20Addr, externalERC20Addr types.Address
 
@@ -168,7 +182,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 
 		// mint erc20
 		for _, acc := range accountAddrs {
-			if err := mint(*erc20Addr, big.NewInt(bridgeAmount*2), acc, relayer); err != nil {
+			if err := mint(*erc20Addr, big.NewInt(bridgeAmount*3), acc, relayer); err != nil {
 				return err
 			}
 		}
@@ -217,22 +231,33 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 		return nil
 	}
 
-	timeoutCtx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
-	g, _ = errgroup.WithContext(timeoutCtx)
+	depositBothSides := func() {
+		// first deposit
+		timeoutCtx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+		g, _ = errgroup.WithContext(timeoutCtx)
 
-	g.Go(func() error {
-		return runTest(internalERC20Addr, bridgeCfg.InternalMintableERC20PredicateAddr, internalJSONRPCAddr)
-	})
+		g.Go(func() error {
+			return runTest(internalERC20Addr, bridgeCfg.InternalMintableERC20PredicateAddr, internalJSONRPCAddr)
+		})
 
-	g.Go(func() error {
-		return runTest(externalERC20Addr, bridgeCfg.ExternalERC20PredicateAddr, externalJSONRPCAddr)
-	})
+		g.Go(func() error {
+			return runTest(externalERC20Addr, bridgeCfg.ExternalERC20PredicateAddr, externalJSONRPCAddr)
+		})
 
-	if err := g.Wait(); err != nil {
-		t.Fatalf("failed to deposit ERC20: %v", err)
+		if err := g.Wait(); err != nil {
+			t.Fatalf("failed to deposit ERC20: %v", err)
+		}
+
+		cancel()
 	}
 
-	cancel()
+	depositBothSides()
+
+	stopRelayerFn(1, 2)
+
+	t.Logf("Deposited first & stopped relayer")
+
+	depositBothSides()
 
 	t.Logf("Deposited ERC20 tokens")
 
@@ -245,7 +270,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 			logs, err := getFilteredLogs((&contractsapi.NewBatchEvent{}).Sig(), 0, latest, internalEndpoint)
 			require.NoError(t, err)
 
-			if len(logs) == 0 {
+			if len(logs) < 2 {
 				return false
 			}
 
@@ -290,31 +315,16 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	}
 
 	// start relayer
-	relayer.Start()
+	cluster.BridgeRelayers[0].Start()
 
 	t.Logf("Restarted validators & relayer")
 
-	timeoutCtx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
-	g, _ = errgroup.WithContext(timeoutCtx)
-
-	g.Go(func() error {
-		return runTest(internalERC20Addr, bridgeCfg.InternalMintableERC20PredicateAddr, internalJSONRPCAddr)
-	})
-
-	g.Go(func() error {
-		return runTest(externalERC20Addr, bridgeCfg.ExternalERC20PredicateAddr, externalJSONRPCAddr)
-	})
-
-	if err := g.Wait(); err != nil {
-		t.Fatalf("failed to deposit ERC20 after validators restart: %v", err)
-	}
-
-	cancel()
+	depositBothSides()
 
 	t.Logf("Deposited ERC20 tokens after validators restart")
 
 	require.NoError(t, cluster.WaitUntil(3*time.Minute, 2*time.Second, func() bool {
-		for i := uint64(1); i <= 2*transfersCount+1; i++ {
+		for i := uint64(1); i <= 3*transfersCount+1; i++ {
 			if !isEventProcessed(t, bridgeCfg.InternalGatewayAddr, internalChainTxRelayer, i, false) {
 				return false
 			}
@@ -334,7 +344,7 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	externalChildToken := getChildToken(t, contractsapi.RootERC20Predicate.Abi,
 		bridgeCfg.ExternalERC20PredicateAddr, externalERC20Addr, externalChainTxRelayer)
 
-	expectedBalance := big.NewInt(bridgeAmount * 2)
+	expectedBalance := big.NewInt(bridgeAmount * 3)
 
 	for _, acc := range accountAddrs {
 		balance1 := erc20BalanceOf(t, acc, internalChildToken, externalChainTxRelayer)
@@ -349,4 +359,19 @@ func TestE2E_Bridge_NetworkFailureAndRestart(t *testing.T) {
 	}
 
 	t.Logf("Test passed")
+}
+
+func init() {
+	wd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	parent := filepath.Dir(wd)
+	parent = strings.Trim(parent, "e2e-polybft")
+	wd = filepath.Join(parent, "/artifacts/blade")
+	os.Setenv("EDGE_BINARY", wd)
+	os.Setenv("E2E_TESTS", "true")
+	os.Setenv("E2E_LOGS", "true")
+	os.Setenv("E2E_LOG_LEVEL", "debug")
 }

--- a/e2e-polybft/bridge/synchronization_test.go
+++ b/e2e-polybft/bridge/synchronization_test.go
@@ -229,7 +229,6 @@ func TestE2E_Bridge_ValidatorSync(t *testing.T) {
 //  5. Compares restarted validator with another active validator to ensure they are in sync and have identical state data.
 //
 // This test validates that validators can correctly resynchronize after being offline
-
 func TestE2E_Bridge_ValidatorSyncExecuted(t *testing.T) {
 	const (
 		transfersCount        = 5
@@ -452,7 +451,6 @@ func TestE2E_Bridge_ValidatorSyncExecuted(t *testing.T) {
 // 4. Starts the validator.
 // 5. Waits for the validator to synchronize.
 // 6. Ensures the validator syncs back correctly after restarting.
-
 func TestE2E_Bridge_ValidatorSyncRollback_E2I(t *testing.T) {
 	const (
 		transfersCount        = 5
@@ -598,7 +596,6 @@ func TestE2E_Bridge_ValidatorSyncRollback_E2I(t *testing.T) {
 // 4. Starts the validator.
 // 5. Waits for the validator to synchronize.
 // 6. Ensures the validator syncs back correctly after restarting.
-
 func TestE2E_Bridge_ValidatorSyncRollback_I2E(t *testing.T) {
 	const (
 		transfersCount   = uint64(5)
@@ -736,7 +733,6 @@ func TestE2E_Bridge_ValidatorSyncRollback_I2E(t *testing.T) {
 // 4. Starts the validator.
 // 5. Waits for the validator to synchronize.
 // 6. Ensures the validator syncs back correctly after restarting.
-
 func TestE2E_Bridge_ValidatorSyncRollbackExecuted_E2I(t *testing.T) {
 	const (
 		transfersCount        = 5
@@ -923,7 +919,6 @@ func TestE2E_Bridge_ValidatorSyncRollbackExecuted_E2I(t *testing.T) {
 // 4. Starts the validator.
 // 5. Waits for the validator to synchronize.
 // 6. Ensures the validator syncs back correctly after restarting
-
 func TestE2E_Bridge_ValidatorSyncRollbackExecuted_I2E(t *testing.T) {
 	const (
 		transfersCount   = uint64(5)


### PR DESCRIPTION
This PR changes the way bridge batch votes are stored — instead of persisting them in BoltDB, votes are now kept in-memory. This is possible, because votes for batches are continuously sent, and upon startup the node will regain all (relevant) votes it lost due to restart.

Additionally, this PR includes several other improvements. Most notably, it introduces comprehensive and detailed documentation covering both the types of buckets that exist and the way they are structured (the bucket tree structure) within BoltDB.

Also, functions (methods) that are no longer used and therefore no longer relevant have been deleted. In addition, all tests (and test helper functions) related to them have been removed.

Finally, unit tests were added for state store methods that did not have them. Therefore, now all state store methods are covered by tests. Also, a bug that existed within the e2e `TestE2E_Bridge_NetworkFailureAndRestart` test is fixed.