### PR TITLE
Add relayer metrics

### DIFF
--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -608,22 +608,11 @@ func (r *BridgeRelayer) Start() {
 					continue
 				}
 
-				metrics.SetGaugeWithLabels([]string{"balance"}, 1,
+				metrics.SetGaugeWithLabels([]string{"balance"}, float32(balance.Uint64()),
 					[]metrics.Label{{
 						Name:  "ID",
 						Value: r.externalChainID.String(),
-					}, {
-						Name:  "current_balance",
-						Value: balance.String(),
 					}})
-
-				b := big.NewInt(0).Div(balance, big.NewInt(1_000_000_000))
-				fmt.Println(balance.String())
-				fmt.Println(b.String())
-				fmt.Println(balance.Uint64())
-				fmt.Println(b.Uint64())
-				fmt.Println(float32(balance.Uint64()))
-				fmt.Println(float32(b.Uint64()))
 			}
 		}
 	}

--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -92,7 +92,8 @@ type BridgeRelayer struct {
 	metricPath string
 
 	// heartbeatThreshold denotes value below which the relayer is considered
-	// dead (from the perspective of metrics and Prometheus).
+	// logically dead, that is, in low balance alarm (from the perspective of
+	// metrics and Prometheus).
 	heartbeatThreshold *big.Int
 
 	// he logger is an instance of the hclog logging library.
@@ -318,7 +319,8 @@ func WithMetricEndpoint(endpoint string) BridgeRelayerOption {
 // WithHeartbeat configures the relayer to report its health status to Prometheus
 // based on its balance on the external chain. When the balance is above the given
 // threshold, it sends an "alive" signal (1). If the balance falls below, the relayer
-// is considered "dead" and starts to send a "dead" signal (0).
+// is considered logically dead, that is, in low balance alarm and starts to send a
+// signal (0).
 //
 // Note: Signals are only sent if a metrics endpoint is exposed (see WithMetricEndpoint).
 func WithHeartbeat(threshold string) BridgeRelayerOption {
@@ -779,7 +781,7 @@ func (r *BridgeRelayer) sendTransaction(input []byte) error {
 
 	defer func() {
 		if receipt == nil || receipt.Status == 0 {
-			metrics.IncrCounterWithLabels([]string{"unsuccessful_tx"}, 1,
+			metrics.IncrCounterWithLabels([]string{"num_of_unsuccessful_txs"}, 1,
 				[]metrics.Label{{
 					Name:  "ID",
 					Value: r.externalChainID.String(),
@@ -805,7 +807,7 @@ func (r *BridgeRelayer) sendTransaction(input []byte) error {
 	)
 
 	if receipt.Status == 1 {
-		metrics.IncrCounterWithLabels([]string{"successful_tx"}, 1,
+		metrics.IncrCounterWithLabels([]string{"num_of_successful_txs"}, 1,
 			[]metrics.Label{{
 				Name:  "ID",
 				Value: r.externalChainID.String(),

--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -6,9 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
+	"net/http"
 	"net/url"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -18,9 +22,13 @@ import (
 	"github.com/0xPolygon/polygon-edge/consensus/polybft/contractsapi"
 	"github.com/0xPolygon/polygon-edge/contracts"
 	"github.com/0xPolygon/polygon-edge/crypto"
+	"github.com/0xPolygon/polygon-edge/jsonrpc"
 	"github.com/0xPolygon/polygon-edge/txrelayer"
+	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/hashicorp/go-hclog"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/0xPolygon/polygon-edge/types"
 )
@@ -76,6 +84,12 @@ type BridgeRelayer struct {
 	// db is a BoltDB instance used for (persistent) local storage.
 	db *bolt.DB
 
+	// metricPort specifies the port where metrics for Prometheus are exposed.
+	metricPort uint16
+
+	// metricPath specifies the path where metrics for Prometheus are exposed.
+	metricPath string
+
 	// he logger is an instance of the hclog logging library.
 	// used to handle application logging.
 	logger hclog.Logger
@@ -109,6 +123,8 @@ type options struct {
 	pollInterval        *time.Duration
 	privateKey          *string
 	dbPath              *string
+	metricPort          *uint16
+	metricPath          *string
 	logLevel            hclog.Level
 	jsonLogFormat       bool
 	logDir              string
@@ -256,6 +272,43 @@ func WithDBPath(path string) BridgeRelayerOption {
 	}
 }
 
+// WithMetricEndpoint configures the relayer to expose metrics for the Prometheus
+// on the given endpoint. Endpoint must be in the format :PORT/PATH, where port
+// is an uint16 and path is defined according to the HTTP path rules.
+func WithMetricEndpoint(endpoint string) BridgeRelayerOption {
+	return func(o *options) error {
+		// Potential additional regex check should be performed to verify
+		// whether the provided endpoint is in the format :PORT/PATH, where
+		// port is an uint16 and path is defined according to HTTP path rules.
+		if !strings.HasPrefix(endpoint, ":") {
+			return fmt.Errorf("endpoint must start with ':'")
+		}
+
+		parts := strings.SplitN(endpoint[1:], "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("endpoint must be in the form ':PORT/PATH'")
+		}
+
+		port, err := strconv.ParseUint(parts[0], 10, 16)
+		if err != nil {
+			return fmt.Errorf("cannot parse port (endpoint): %w", err)
+		}
+
+		if port == 0 {
+			return fmt.Errorf("port cannot be zero")
+		}
+
+		port16 := uint16(port)
+
+		path := "/" + parts[1]
+
+		o.metricPort = &port16
+		o.metricPath = &path
+
+		return nil
+	}
+}
+
 func WithLogLevel(level hclog.Level) BridgeRelayerOption {
 	return func(options *options) error {
 		options.logLevel = level
@@ -370,10 +423,60 @@ func NewBridgeRelayer(internalRPCAddr string, privateKey string, opts ...BridgeR
 		return nil, errFunc(err)
 	}
 
+	if sopts.metricPort != nil && sopts.metricPath != nil {
+		relayer.metricPort = *sopts.metricPort
+		relayer.metricPath = *sopts.metricPath
+	}
+
 	return relayer, nil
 }
 
+func (r *BridgeRelayer) startPrometheusMetricsServer() {
+	sink, err := prometheus.NewPrometheusSink()
+	if err != nil {
+		log.Fatalf("failed to create prometheus sink: %v", err)
+	}
+
+	conf := metrics.DefaultConfig("bridge_relayer")
+
+	_, err = metrics.NewGlobal(conf, sink)
+	if err != nil {
+		log.Fatalf("failed to create metrics: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		promhttp.Handler().ServeHTTP(w, r)
+	})
+
+	r.logger.Info("starting Prometheus metrics server",
+		"port", r.metricPort,
+		"path", r.metricPath)
+
+	srv := &http.Server{
+		Addr:         ":54321",
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	go func() {
+		log.Fatal(srv.ListenAndServe())
+	}()
+}
+
 func (r *BridgeRelayer) Start() {
+	if r.metricPort != 0 && r.metricPath != "" {
+		r.startPrometheusMetricsServer()
+	}
+
 	lastBridged := big.NewInt(-1)
 
 	bucketName := []byte("lastBridgedBucket")
@@ -414,6 +517,13 @@ func (r *BridgeRelayer) Start() {
 	for {
 		select {
 		case <-t.C:
+			// A metric indicating that the relayer is active – relayer’s heartbeat.
+			metrics.SetGaugeWithLabels([]string{"active"}, 1,
+				[]metrics.Label{{
+					Name:  "ID",
+					Value: r.externalChainID.String(),
+				}})
+
 			r.logger.Info(fmt.Sprintf("getting new batches with id > %s", lastBridged.String()))
 
 			batches, err := GetBridgeBatchesFromNumber(big.NewInt(0).Add(lastBridged, big.NewInt(1)), r.internalClient)
@@ -492,6 +602,17 @@ func (r *BridgeRelayer) Start() {
 				r.logger.Info("batch has been successfully saved into bolt DB", "batch id", lastBridged.String())
 
 				batchNum = 0
+
+				balance, err := r.externalClient.Client().GetBalance(r.privateKey.Address(), jsonrpc.LatestBlockNumberOrHash)
+				if err != nil {
+					continue
+				}
+
+				metrics.SetGaugeWithLabels([]string{"balance"}, float32(balance.Uint64()),
+					[]metrics.Label{{
+						Name:  "ID",
+						Value: r.externalChainID.String(),
+					}})
 			}
 		}
 	}
@@ -571,6 +692,8 @@ func newLoggerFromConfig(options *options) (hclog.Logger, error) {
 }
 
 func (r *BridgeRelayer) sendSignedBridgeMessageBatch(batch *contractsapi.SignedBridgeMessageBatch) error {
+	r.logger.Info("attempting to send a transaction with bridge messages")
+
 	input, err := (&contractsapi.ReceiveBatchGatewayFn{
 		SignedBatch: batch,
 	}).EncodeAbi()
@@ -578,28 +701,12 @@ func (r *BridgeRelayer) sendSignedBridgeMessageBatch(batch *contractsapi.SignedB
 		return fmt.Errorf("failed to encode abi, err: %w", err)
 	}
 
-	tx := types.NewTx(types.NewLegacyTx(
-		types.WithFrom(r.privateKey.Address()),
-		types.WithTo(&r.externalGatewayAddr),
-		types.WithInput(input),
-	))
-
-	receipt, err := r.externalClient.SendTransaction(tx, r.privateKey)
-	if err != nil {
-		return fmt.Errorf("id-ed batch has already been processed or cannot be processed, err: %w", err)
-	}
-
-	r.logger.Debug("sent commit bridge message batch transaction to external chain",
-		"gatewayAddr", r.externalGatewayAddr,
-		"status", types.ReceiptStatus(receipt.Status),
-		"txHash", receipt.TransactionHash,
-		"blockNumber", receipt.BlockNumber,
-	)
-
-	return nil
+	return r.sendTransaction(input)
 }
 
 func (r *BridgeRelayer) sendCommitValidatorSet(newValidatorSet *contractsapi.SignedValidatorSet) error {
+	r.logger.Info("attempting to send a transaction to commit a new validator set")
+
 	input, err := (&contractsapi.CommitValidatorSetBridgeStorageFn{
 		NewValidatorSet: newValidatorSet.NewValidatorSet,
 		Signature:       newValidatorSet.Signature,
@@ -610,23 +717,64 @@ func (r *BridgeRelayer) sendCommitValidatorSet(newValidatorSet *contractsapi.Sig
 		return err
 	}
 
+	return r.sendTransaction(input)
+}
+
+func (r *BridgeRelayer) sendTransaction(input []byte) error {
 	txn := types.NewTx(types.NewLegacyTx(
 		types.WithFrom(r.privateKey.Address()),
 		types.WithTo(&r.externalGatewayAddr),
 		types.WithInput(input),
 	))
 
+	d := time.Duration(0)
+
+	defer func() {
+		metrics.SetGaugeWithLabels([]string{"processing_time"}, float32(d.Milliseconds()),
+			[]metrics.Label{{
+				Name:  "ID",
+				Value: r.externalChainID.String(),
+			}})
+	}()
+
+	t := time.Now().UTC()
 	receipt, err := r.externalClient.SendTransaction(txn, r.privateKey)
+	d = time.Since(t)
+
+	defer func() {
+		if receipt == nil || receipt.Status == 0 {
+			metrics.IncrCounterWithLabels([]string{"unsuccessful_tx"}, 1,
+				[]metrics.Label{{
+					Name:  "ID",
+					Value: r.externalChainID.String(),
+				}})
+		}
+	}()
+
 	if err != nil {
-		return fmt.Errorf("failed to send commit validator set transaction to external chain, err: %w", err)
+		return fmt.Errorf("failed to send transaction to the external chain, err: %w", err)
 	}
 
-	r.logger.Debug("sent commit validator set transaction to external chain",
+	metrics.SetGaugeWithLabels([]string{"gas_used"}, float32(receipt.GasUsed),
+		[]metrics.Label{{
+			Name:  "ID",
+			Value: r.externalChainID.String(),
+		}})
+
+	r.logger.Info("transaction successfully sent (and processed) to the external chain",
 		"gatewayAddr", r.externalGatewayAddr,
 		"status", types.ReceiptStatus(receipt.Status),
 		"txHash", receipt.TransactionHash,
 		"blockNumber", receipt.BlockNumber,
 	)
+
+	if receipt.Status == 1 {
+		metrics.IncrCounterWithLabels([]string{"successful_tx"}, 1,
+			[]metrics.Label{{
+				Name:  "ID",
+				Value: r.externalChainID.String(),
+			}})
+	}
 
 	return nil
 }

--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	bolt "go.etcd.io/bbolt"
 
@@ -90,6 +91,10 @@ type BridgeRelayer struct {
 	// metricPath specifies the path where metrics for Prometheus are exposed.
 	metricPath string
 
+	// heartbeatThreshold denotes value below which the relayer is considered
+	// dead (from the perspective of metrics and Prometheus).
+	heartbeatThreshold *big.Int
+
 	// he logger is an instance of the hclog logging library.
 	// used to handle application logging.
 	logger hclog.Logger
@@ -125,6 +130,7 @@ type options struct {
 	dbPath              *string
 	metricPort          *uint16
 	metricPath          *string
+	heartbeatThreshold  *string
 	logLevel            hclog.Level
 	jsonLogFormat       bool
 	logDir              string
@@ -309,6 +315,30 @@ func WithMetricEndpoint(endpoint string) BridgeRelayerOption {
 	}
 }
 
+// WithHeartbeat configures the relayer to report its health status to Prometheus
+// based on its balance on the external chain. When the balance is above the given
+// threshold, it sends an "alive" signal (1). If the balance falls below, the relayer
+// is considered "dead" and starts to send a "dead" signal (0).
+//
+// Note: Signals are only sent if a metrics endpoint is exposed (see WithMetricEndpoint).
+func WithHeartbeat(threshold string) BridgeRelayerOption {
+	return func(o *options) error {
+		if threshold == "" {
+			return fmt.Errorf("heartbeat threshold cannot be empty")
+		}
+
+		for _, r := range threshold {
+			if !unicode.IsDigit(r) {
+				return fmt.Errorf("heartbeat threshold must be a number")
+			}
+		}
+
+		o.heartbeatThreshold = &threshold
+
+		return nil
+	}
+}
+
 func WithLogLevel(level hclog.Level) BridgeRelayerOption {
 	return func(options *options) error {
 		options.logLevel = level
@@ -428,6 +458,10 @@ func NewBridgeRelayer(internalRPCAddr string, privateKey string, opts ...BridgeR
 		relayer.metricPath = *sopts.metricPath
 	}
 
+	if sopts.heartbeatThreshold != nil {
+		relayer.heartbeatThreshold, _ = big.NewInt(0).SetString(*sopts.heartbeatThreshold, 10)
+	}
+
 	return relayer, nil
 }
 
@@ -517,12 +551,25 @@ func (r *BridgeRelayer) Start() {
 	for {
 		select {
 		case <-t.C:
-			// A metric indicating that the relayer is active – relayer’s heartbeat.
-			metrics.SetGaugeWithLabels([]string{"active"}, 1,
-				[]metrics.Label{{
-					Name:  "ID",
-					Value: r.externalChainID.String(),
-				}})
+			balance, err := r.externalClient.Client().GetBalance(r.privateKey.Address(), jsonrpc.LatestBlockNumberOrHash)
+			if err != nil {
+				continue
+			}
+
+			alive := 1
+
+			if r.heartbeatThreshold != nil && balance.Cmp(r.heartbeatThreshold) <= 0 {
+				alive = 0
+			}
+
+			if r.heartbeatThreshold != nil {
+				// A metric indicating that the relayer is active – relayer’s heartbeat.
+				metrics.SetGaugeWithLabels([]string{"heartbeat"}, float32(alive),
+					[]metrics.Label{{
+						Name:  "ID",
+						Value: r.externalChainID.String(),
+					}})
+			}
 
 			r.logger.Info(fmt.Sprintf("getting new batches with id > %s", lastBridged.String()))
 
@@ -602,17 +649,6 @@ func (r *BridgeRelayer) Start() {
 				r.logger.Info("batch has been successfully saved into bolt DB", "batch id", lastBridged.String())
 
 				batchNum = 0
-
-				balance, err := r.externalClient.Client().GetBalance(r.privateKey.Address(), jsonrpc.LatestBlockNumberOrHash)
-				if err != nil {
-					continue
-				}
-
-				metrics.SetGaugeWithLabels([]string{"balance"}, float32(balance.Uint64()),
-					[]metrics.Label{{
-						Name:  "ID",
-						Value: r.externalChainID.String(),
-					}})
 			}
 		}
 	}

--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -460,7 +460,7 @@ func (r *BridgeRelayer) startPrometheusMetricsServer() {
 		"path", r.metricPath)
 
 	srv := &http.Server{
-		Addr:         ":54321",
+		Addr:         fmt.Sprintf(":%v", r.metricPort),
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -608,11 +608,22 @@ func (r *BridgeRelayer) Start() {
 					continue
 				}
 
-				metrics.SetGaugeWithLabels([]string{"balance"}, float32(balance.Uint64()),
+				metrics.SetGaugeWithLabels([]string{"balance"}, 1,
 					[]metrics.Label{{
 						Name:  "ID",
 						Value: r.externalChainID.String(),
+					}, {
+						Name:  "current_balance",
+						Value: balance.String(),
 					}})
+
+				b := big.NewInt(0).Div(balance, big.NewInt(1_000_000_000))
+				fmt.Println(balance.String())
+				fmt.Println(b.String())
+				fmt.Println(balance.Uint64())
+				fmt.Println(b.Uint64())
+				fmt.Println(float32(balance.Uint64()))
+				fmt.Println(float32(b.Uint64()))
 			}
 		}
 	}

--- a/bridge-relayer/relayer.go
+++ b/bridge-relayer/relayer.go
@@ -318,8 +318,9 @@ func WithMetricEndpoint(endpoint string) BridgeRelayerOption {
 
 // WithHeartbeat configures the relayer to report its health status to Prometheus
 // based on its balance on the external chain. When the balance is above the given
-// threshold, it sends an "alive" signal (1). If the balance falls below, the relayer
-// is considered logically dead, that is, in low balance alarm and starts to send a
+// threshold (expressed in the lowest unit of the external chain native token, e.g.
+// wei), it sends an "alive" signal (1). If the balance falls below, the relayer is
+// considered logically dead, that is, in low balance alarm and starts to send a
 // signal (0).
 //
 // Note: Signals are only sent if a metrics endpoint is exposed (see WithMetricEndpoint).

--- a/command/bridge-relayer/params.go
+++ b/command/bridge-relayer/params.go
@@ -29,11 +29,11 @@ type commandParams struct {
 	// which metrics for Prometheus will be exposed.
 	metricsEndpoint string
 
-	// heartbeatThreshold denotes balance (expressed in external chain native tokens)
-	// below which the relayer is considered inactive. When the relayer's balance falls
-	// below this value, the relayer will be marked as 'dead', that is, it will sends
-	// 0 instead of 1 to Prometheus. This param only takes effect if the metricsEndpoint
-	// is set/configured.
+	// heartbeatThreshold denotes balance (expressed in the lowest unit (e.g. wei)
+	// of the external chain native tokens) below which the relayer is considered
+	// in alarm. When the relayer's balance falls below this value, the relayer will
+	// signal an alarm, that is, it will send 0 instead of 1 to Prometheus. This
+	// param only takes effect if the metricsEndpoint is set/configured.
 	heartbeatThreshold string
 
 	// this parameter enables JSON-formatted logs by setting its value to true.

--- a/command/bridge-relayer/params.go
+++ b/command/bridge-relayer/params.go
@@ -29,6 +29,13 @@ type commandParams struct {
 	// which metrics for Prometheus will be exposed.
 	metricsEndpoint string
 
+	// heartbeatThreshold denotes balance (expressed in external chain native tokens)
+	// below which the relayer is considered inactive. When the relayer's balance falls
+	// below this value, the relayer will be marked as 'dead', that is, it will sends
+	// 0 instead of 1 to Prometheus. This param only takes effect if the metricsEndpoint
+	// is set/configured.
+	heartbeatThreshold string
+
 	// this parameter enables JSON-formatted logs by setting its value to true.
 	jsonFormatOuttputter bool
 

--- a/command/bridge-relayer/params.go
+++ b/command/bridge-relayer/params.go
@@ -25,6 +25,10 @@ type commandParams struct {
 	// exposed or committed to any public service or version control system.
 	relayerPrivateKey string
 
+	// metricsEndpoint specifies the port and path (in the format :PORT/PATH) on
+	// which metrics for Prometheus will be exposed.
+	metricsEndpoint string
+
 	// this parameter enables JSON-formatted logs by setting its value to true.
 	jsonFormatOuttputter bool
 

--- a/command/bridge-relayer/relayer.go
+++ b/command/bridge-relayer/relayer.go
@@ -32,6 +32,7 @@ func runCommand(*cobra.Command, []string) {
 		bridgerelayer.WithLogJSONFormat(params.jsonFormatOuttputter),
 		bridgerelayer.WithDBPath(params.boltDBPath),
 		bridgerelayer.WithMetricEndpoint(params.metricsEndpoint),
+		bridgerelayer.WithHeartbeat(params.heartbeatThreshold),
 	)
 
 	if err != nil {
@@ -128,5 +129,12 @@ func setFlags(cmd *cobra.Command) {
 		"m",
 		"",
 		"endpoint where metrics for prometheus will be exposed (must be in :PORT/PATH format)",
+	)
+
+	cmd.Flags().StringVar(
+		&params.heartbeatThreshold,
+		"hearbeat-threshold",
+		"100000",
+		"relayer's balance below whitch it is considered dead in context of Prometheus metrics",
 	)
 }

--- a/command/bridge-relayer/relayer.go
+++ b/command/bridge-relayer/relayer.go
@@ -134,7 +134,8 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&params.heartbeatThreshold,
 		"hearbeat-threshold",
-		"100000",
-		"relayer's balance below whitch it is considered dead in context of Prometheus metrics",
+		"100000000000000000", // 0.1 eth
+		"relayer's balance on the external chain (expressed in the lowest unit; e.g. wei) below"+
+			"which it is considered in low balance alarm in context of Prometheus metrics",
 	)
 }

--- a/command/bridge-relayer/relayer.go
+++ b/command/bridge-relayer/relayer.go
@@ -31,6 +31,7 @@ func runCommand(*cobra.Command, []string) {
 		bridgerelayer.WithLogLevel(hclog.LevelFromString(params.logLevel)),
 		bridgerelayer.WithLogJSONFormat(params.jsonFormatOuttputter),
 		bridgerelayer.WithDBPath(params.boltDBPath),
+		bridgerelayer.WithMetricEndpoint(params.metricsEndpoint),
 	)
 
 	if err != nil {
@@ -119,5 +120,13 @@ func setFlags(cmd *cobra.Command) {
 		"database-path",
 		"",
 		"path to bolt database",
+	)
+
+	cmd.Flags().StringVarP(
+		&params.metricsEndpoint,
+		"metrics-endpoint",
+		"m",
+		"",
+		"endpoint where metrics for prometheus will be exposed (must be in :PORT/PATH format)",
 	)
 }

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -9,12 +9,14 @@ import (
 	"math/big"
 	"net"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/Ethernal-Tech/blockchain-event-tracker/store"
 	"github.com/Ethernal-Tech/blockchain-event-tracker/tracker"
 	"github.com/Ethernal-Tech/ethgo"
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/libp2p/go-libp2p/core/peer"
 	bolt "go.etcd.io/bbolt"
@@ -1371,6 +1373,12 @@ func (b *bridgeEventManager) handleBridgeMessageEvent(
 		return err
 	}
 
+	metrics.IncrCounterWithLabels([]string{"num_of_pending_bridge_messages"}, 1,
+		[]metrics.Label{{
+			Name:  "ID",
+			Value: strconv.Itoa(int(b.externalChainID)),
+		}})
+
 	msg := &contractsapi.BridgeMessage{
 		ID:                 id,
 		SourceChainID:      sid,
@@ -1464,6 +1472,18 @@ func (b *bridgeEventManager) handleBridgeMessageResultEvent(
 			b.logger.Info(fmt.Sprintf("Rollback bridge message %s has been successfully processed",
 				id.String()))
 
+			metrics.IncrCounterWithLabels([]string{"num_of_successful_bridge_messages"}, 1,
+				[]metrics.Label{{
+					Name:  "ID",
+					Value: strconv.Itoa(int(b.externalChainID)),
+				}})
+
+			metrics.IncrCounterWithLabels([]string{"num_of_pending_bridge_messages"}, -1,
+				[]metrics.Label{{
+					Name:  "ID",
+					Value: strconv.Itoa(int(b.externalChainID)),
+				}})
+
 			return nil
 		}
 
@@ -1503,10 +1523,28 @@ func (b *bridgeEventManager) finalizeOrdinaryBridgeMessage(
 			return err
 		}
 
+		metrics.IncrCounterWithLabels([]string{"num_of_successful_bridge_messages"}, 1,
+			[]metrics.Label{{
+				Name:  "ID",
+				Value: strconv.Itoa(int(b.externalChainID)),
+			}})
+
+		metrics.IncrCounterWithLabels([]string{"num_of_pending_bridge_messages"}, -1,
+			[]metrics.Label{{
+				Name:  "ID",
+				Value: strconv.Itoa(int(b.externalChainID)),
+			}})
+
 		b.logger.Info(fmt.Sprintf("Bridge message %s has been successfully processed", id.String()))
 
 		return nil
 	}
+
+	metrics.IncrCounterWithLabels([]string{"num_of_unsuccessful_bridge_messages"}, 1,
+		[]metrics.Label{{
+			Name:  "ID",
+			Value: strconv.Itoa(int(b.externalChainID)),
+		}})
 
 	rollbackMsg, err := b.state.getBridgeMessageEvent(id, sid, did, false, dbTx)
 	if err != nil {

--- a/consensus/polybft/bridge/bridge_manager.go
+++ b/consensus/polybft/bridge/bridge_manager.go
@@ -1546,6 +1546,11 @@ func (b *bridgeEventManager) finalizeOrdinaryBridgeMessage(
 			Value: strconv.Itoa(int(b.externalChainID)),
 		}})
 
+	// In this case, we don't decrease the number of pending messages (in the context of metrics),
+	// because even though the ordinary message is executed (and the number of pending messages
+	// should decreases by one), a new rollback message is created, thus the number of pending
+	// messages remains the same.
+
 	rollbackMsg, err := b.state.getBridgeMessageEvent(id, sid, did, false, dbTx)
 	if err != nil {
 		b.logger.Error("could not get ordinary bridge message", "err", err)

--- a/e2e-polybft/framework/test-bridge-relayer.go
+++ b/e2e-polybft/framework/test-bridge-relayer.go
@@ -62,6 +62,7 @@ func (t *TestRelayer) Start() {
 		"--poll-interval", strconv.Itoa(5),
 		"--database-path", fmt.Sprintf("%s/bridge-relayer-%d.db", filepath.Dir(t.t.TempDir()), t.externalChainID),
 		"--metrics-endpoint", fmt.Sprintf(":%v/", t.metricPort),
+		"--hearbeat-threshold", "999999999910527511497316", // this value should be much lower in real use
 	}
 
 	stdout := t.clusterConfig.GetStdout("bridge-relayer")

--- a/e2e-polybft/framework/test-bridge-relayer.go
+++ b/e2e-polybft/framework/test-bridge-relayer.go
@@ -18,6 +18,7 @@ type TestRelayer struct {
 	genesisPath      string
 	key              *crypto.ECDSAKey
 	validatorJSONRPC string
+	metricPort       uint16 // prometheus
 
 	node *node
 }
@@ -28,7 +29,8 @@ func NewTestBridgeRelayer(
 	externalChainID uint64,
 	genesisPath string,
 	key *crypto.ECDSAKey,
-	validatorJSONRPC string) *TestRelayer {
+	validatorJSONRPC string,
+	metricPort uint16) *TestRelayer {
 	t.Helper()
 
 	relayer := &TestRelayer{
@@ -38,6 +40,7 @@ func NewTestBridgeRelayer(
 		genesisPath:      genesisPath,
 		key:              key,
 		validatorJSONRPC: validatorJSONRPC,
+		metricPort:       metricPort,
 	}
 
 	return relayer
@@ -58,7 +61,7 @@ func (t *TestRelayer) Start() {
 		"--external-chain-id", strconv.FormatUint(t.externalChainID, 10),
 		"--poll-interval", strconv.Itoa(5),
 		"--database-path", fmt.Sprintf("%s/bridge-relayer-%d.db", filepath.Dir(t.t.TempDir()), t.externalChainID),
-		"--metrics-endpoint", fmt.Sprintf(":54321/"),
+		"--metrics-endpoint", fmt.Sprintf(":%v/", t.metricPort),
 	}
 
 	stdout := t.clusterConfig.GetStdout("bridge-relayer")

--- a/e2e-polybft/framework/test-bridge-relayer.go
+++ b/e2e-polybft/framework/test-bridge-relayer.go
@@ -58,6 +58,7 @@ func (t *TestRelayer) Start() {
 		"--external-chain-id", strconv.FormatUint(t.externalChainID, 10),
 		"--poll-interval", strconv.Itoa(5),
 		"--database-path", fmt.Sprintf("%s/bridge-relayer-%d.db", filepath.Dir(t.t.TempDir()), t.externalChainID),
+		"--metrics-endpoint", fmt.Sprintf(":54321/"),
 	}
 
 	stdout := t.clusterConfig.GetStdout("bridge-relayer")

--- a/e2e-polybft/framework/test-cluster.go
+++ b/e2e-polybft/framework/test-cluster.go
@@ -885,7 +885,8 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 			1,
 			cluster.Config.Dir(command.DefaultGenesisFileName),
 			cluster.Config.RelayerPrivateKey,
-			cluster.Servers[0].JSONRPCAddr())
+			cluster.Servers[0].JSONRPCAddr(),
+			54321)
 
 		cluster.BridgeRelayers[0] = bridgeRelayer
 		bridgeRelayer.Start()
@@ -901,7 +902,8 @@ func NewTestCluster(t *testing.T, validatorsCount int, opts ...ClusterOption) *T
 				i+1,
 				cluster.Config.Dir(command.DefaultGenesisFileName),
 				key,
-				cluster.Servers[0].JSONRPCAddr())
+				cluster.Servers[0].JSONRPCAddr(),
+				uint16(54321+i))
 
 			cluster.BridgeRelayers[i] = bridgeRelayer
 			bridgeRelayer.Start()


### PR DESCRIPTION
This PR introduces a mechanism that enables tracking of various metrics related to bridge relayer behavior. The metrics being tracked are as follows:
1. number of successfully transferred batches - counter metric (`num_of_successful_txs`),
2. number of unsuccessfully transferred batches (this can happen due to incorrect signatures - such as when the validator set changes - or when the relayer doesn't have sufficient funds on the external chain) - counter metric (`num_of_unsuccessful_txs`),
3. amount of gas used per transaction to transfer batch - gauge metric (`gas_used`),
4. time required to transfer the batch (time needed for a transaction transferring a batch to be registered as accepted on the external chain by the relayer) - gauge metric (`processing_time`), and
5. heartbeat signal that sends 1 as long as the relayer has sufficient funds on the external chain, and 0 when the amount falls below a threshold; the threshold is defined via the newly added `heartbeat-threshold` flag - counter metric (`heartbeat`).

Additionally, an endpoint has been added (configurable through the `metrics-endpoint` flag) along with all logic that allows a Prometheus client to collect the previously listed metrics and display them in its environment.

Furthermore, some metrics related to the bridge itself have been implemented:
1. number of successfully executed messages - counter metric (`num_of_successful_bridge_messages`),
2. number of unsuccessfully executed messages - counter metric (`num_of_unsuccessful_bridge_messages`), and
3. number of messages waiting to be executed - counter metric (`num_of_pending_bridge_messages`).
