### PR TITLE
GetTransactionReceipt caching

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -438,14 +438,9 @@ func (b *Blockchain) GetTD(hash types.Hash) (*big.Int, bool) {
 	return b.readTotalDifficulty(hash)
 }
 
-// GetReceiptsByHash returns the receipts by block hash
-func (b *Blockchain) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
-	n, err := b.db.ReadBlockLookup(hash)
-	if err != nil {
-		return nil, err
-	}
-
-	return b.db.ReadReceipts(n, hash)
+// GetReceiptsByHash returns the receipts by block number and hash
+func (b *Blockchain) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
+	return b.db.ReadReceipts(num, hash)
 }
 
 // GetBodyByHash returns the body by their hash

--- a/blockchain/storagev2/testing_perf.go
+++ b/blockchain/storagev2/testing_perf.go
@@ -97,13 +97,11 @@ func createBlock(b *testing.B) *types.FullBlock {
 func updateBlock(b *testing.B, num uint64, fb *types.FullBlock) *types.FullBlock {
 	b.Helper()
 
-	var addr types.Address
-
 	fb.Block.Header.Number = num
 	fb.Block.Header.ParentHash = types.StringToHash(randStringBytes(b, 12))
 
 	for i := range fb.Block.Transactions {
-		addr = types.StringToAddress(randStringBytes(b, 8))
+		addr := types.StringToAddress(randStringBytes(b, 8))
 		fb.Block.Transactions[i].SetTo(&addr)
 		fb.Block.Transactions[i].ComputeHash()
 		fb.Receipts[i].TxHash = fb.Block.Transactions[i].Hash()

--- a/command/server/config/config.go
+++ b/command/server/config/config.go
@@ -15,28 +15,30 @@ import (
 
 // Config defines the server configuration params
 type Config struct {
-	GenesisPath              string     `json:"chain_config" yaml:"chain_config"`
-	SecretsConfigPath        string     `json:"secrets_config" yaml:"secrets_config"`
-	DataDir                  string     `json:"data_dir" yaml:"data_dir"`
-	BlockGasTarget           string     `json:"block_gas_target" yaml:"block_gas_target"`
-	GRPCAddr                 string     `json:"grpc_addr" yaml:"grpc_addr"`
-	JSONRPCAddr              string     `json:"jsonrpc_addr" yaml:"jsonrpc_addr"`
-	Telemetry                *Telemetry `json:"telemetry" yaml:"telemetry"`
-	Network                  *Network   `json:"network" yaml:"network"`
-	ShouldSeal               bool       `json:"seal" yaml:"seal"`
-	TxPool                   *TxPool    `json:"tx_pool" yaml:"tx_pool"`
-	LogLevel                 string     `json:"log_level" yaml:"log_level"`
-	RestoreFile              string     `json:"restore_file" yaml:"restore_file"`
-	Headers                  *Headers   `json:"headers" yaml:"headers"`
-	LogFilePath              string     `json:"log_to" yaml:"log_to"`
-	JSONRPCBatchRequestLimit uint64     `json:"jsonrpc_batch_request_limit" yaml:"jsonrpc_batch_request_limit"`
-	JSONRPCBlockRangeLimit   uint64     `json:"jsonrpc_block_range_limit" yaml:"jsonrpc_block_range_limit"`
-	JSONLogFormat            bool       `json:"json_log_format" yaml:"json_log_format"`
-	CorsAllowedOrigins       []string   `json:"cors_allowed_origins" yaml:"cors_allowed_origins"`
-	UseTLS                   bool       `json:"use_tls" yaml:"use_tls"`
-	TLSCertFile              string     `json:"tls_cert_file" yaml:"tls_cert_file"`
-	TLSKeyFile               string     `json:"tls_key_file" yaml:"tls_key_file"`
-	DBEngine                 string     `json:"db_engine" yaml:"db_engine"`
+	GenesisPath              string        `json:"chain_config" yaml:"chain_config"`
+	SecretsConfigPath        string        `json:"secrets_config" yaml:"secrets_config"`
+	DataDir                  string        `json:"data_dir" yaml:"data_dir"`
+	BlockGasTarget           string        `json:"block_gas_target" yaml:"block_gas_target"`
+	GRPCAddr                 string        `json:"grpc_addr" yaml:"grpc_addr"`
+	JSONRPCAddr              string        `json:"jsonrpc_addr" yaml:"jsonrpc_addr"`
+	Telemetry                *Telemetry    `json:"telemetry" yaml:"telemetry"`
+	Network                  *Network      `json:"network" yaml:"network"`
+	ShouldSeal               bool          `json:"seal" yaml:"seal"`
+	TxPool                   *TxPool       `json:"tx_pool" yaml:"tx_pool"`
+	LogLevel                 string        `json:"log_level" yaml:"log_level"`
+	RestoreFile              string        `json:"restore_file" yaml:"restore_file"`
+	Headers                  *Headers      `json:"headers" yaml:"headers"`
+	LogFilePath              string        `json:"log_to" yaml:"log_to"`
+	JSONRPCBatchRequestLimit uint64        `json:"jsonrpc_batch_request_limit" yaml:"jsonrpc_batch_request_limit"`
+	JSONRPCBlockRangeLimit   uint64        `json:"jsonrpc_block_range_limit" yaml:"jsonrpc_block_range_limit"`
+	JSONLogFormat            bool          `json:"json_log_format" yaml:"json_log_format"`
+	CorsAllowedOrigins       []string      `json:"cors_allowed_origins" yaml:"cors_allowed_origins"`
+	UseTLS                   bool          `json:"use_tls" yaml:"use_tls"`
+	TLSCertFile              string        `json:"tls_cert_file" yaml:"tls_cert_file"`
+	TLSKeyFile               string        `json:"tls_key_file" yaml:"tls_key_file"`
+	DBEngine                 string        `json:"db_engine" yaml:"db_engine"`
+	BlockCacheTTL            time.Duration `json:"block_cache_ttl" yaml:"block_cache_ttl"`
+	BlockCacheCapacity       uint64        `json:"block_cache_capacity" yaml:"block_cache_capacity"`
 
 	Relayer bool `json:"relayer" yaml:"relayer"`
 
@@ -159,6 +161,8 @@ func DefaultConfig() *Config {
 		TLSCertFile:              "",
 		TLSKeyFile:               "",
 		DBEngine:                 "pebble",
+		BlockCacheTTL:            3 * time.Minute,
+		BlockCacheCapacity:       50,
 		JSONRPCBatchRequestLimit: DefaultJSONRPCBatchRequestLimit,
 		JSONRPCBlockRangeLimit:   DefaultJSONRPCBlockRangeLimit,
 		Relayer:                  false,

--- a/command/server/params.go
+++ b/command/server/params.go
@@ -44,6 +44,8 @@ const (
 	gossipMessageSizeFlag        = "gossip-msg-size"
 	txGossipBatchSizeFlag        = "tx-gossip-batch-size"
 	journalRotateSizeFlag        = "journal-rotate-size"
+	blockCacheTTLFlag            = "block-cache-ttl"
+	blockCacheCapacityFlag       = "block-cache-capacity"
 
 	relayerFlag = "relayer"
 
@@ -197,6 +199,8 @@ func (p *serverParams) generateConfig() *server.Config {
 		TLSCertFile:        p.rawConfig.TLSCertFile,
 		TLSKeyFile:         p.rawConfig.TLSKeyFile,
 		DBEngine:           p.rawConfig.DBEngine,
+		BlockCacheTTL:      p.rawConfig.BlockCacheTTL,
+		BlockCacheCapacity: p.rawConfig.BlockCacheCapacity,
 
 		Relayer:         p.relayer,
 		MetricsInterval: p.rawConfig.MetricsInterval,

--- a/command/server/server.go
+++ b/command/server/server.go
@@ -264,6 +264,20 @@ func setFlags(cmd *cobra.Command) {
 		"database to be used in blade, possible values 'pebble' (default) and 'leveldb'",
 	)
 
+	cmd.Flags().DurationVar(
+		&params.rawConfig.BlockCacheTTL,
+		blockCacheTTLFlag,
+		defaultConfig.BlockCacheTTL,
+		"time for block cache item to be kept in the cache since last touch",
+	)
+
+	cmd.Flags().Uint64Var(
+		&params.rawConfig.BlockCacheCapacity,
+		blockCacheCapacityFlag,
+		defaultConfig.BlockCacheCapacity,
+		"maximum number of block cache items to be kept in the cache",
+	)
+
 	cmd.Flags().BoolVar(
 		&params.rawConfig.Relayer,
 		relayerFlag,

--- a/consensus/polybft/blockchain_wrapper.go
+++ b/consensus/polybft/blockchain_wrapper.go
@@ -64,8 +64,8 @@ type blockchainBackend interface {
 	// GetChainID returns chain id of the current blockchain
 	GetChainID() uint64
 
-	// GetReceiptsByHash retrieves receipts by hash
-	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+	// GetReceiptsByHash retrieves receipts by block number and hash
+	GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error)
 }
 
 var _ blockchainBackend = &blockchainWrapper{}
@@ -188,8 +188,8 @@ func (p *blockchainWrapper) GetChainID() uint64 {
 	return uint64(p.blockchain.Config().ChainID)
 }
 
-func (p *blockchainWrapper) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
-	return p.blockchain.GetReceiptsByHash(hash)
+func (p *blockchainWrapper) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
+	return p.blockchain.GetReceiptsByHash(num, hash)
 }
 
 var _ contract.Provider = &stateProvider{}

--- a/consensus/polybft/mocks_test.go
+++ b/consensus/polybft/mocks_test.go
@@ -123,7 +123,7 @@ func (m *blockchainMock) GetChainID() uint64 {
 	return 0
 }
 
-func (m *blockchainMock) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+func (m *blockchainMock) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
 	args := m.Called(hash)
 
 	return args.Get(0).([]*types.Receipt), args.Error(1)

--- a/consensus/polybft/state_event_getter.go
+++ b/consensus/polybft/state_event_getter.go
@@ -156,7 +156,7 @@ func (r *receiptsGetter) getReceiptsFromBlocksRange(from, to uint64,
 			return blockchain.ErrNoBlock
 		}
 
-		receipts, err := r.blockchain.GetReceiptsByHash(blockHeader.Hash)
+		receipts, err := r.blockchain.GetReceiptsByHash(i, blockHeader.Hash)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/hashicorp/hcl v1.0.1-vault-7
 	github.com/hashicorp/vault/api v1.16.0
 	github.com/holiman/uint256 v1.3.2
+	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/libp2p/go-libp2p v0.41.1
 	github.com/libp2p/go-libp2p-kbucket v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -467,6 +467,8 @@ github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/jsonrpc/debug_endpoint.go
+++ b/jsonrpc/debug_endpoint.go
@@ -47,8 +47,8 @@ type debugBlockchainStore interface {
 	// GetHeaderByNumber gets a header using the provided number
 	GetHeaderByNumber(uint64) (*types.Header, bool)
 
-	// GetReceiptsByHash returns the receipts by block hash
-	GetReceiptsByHash(types.Hash) ([]*types.Receipt, error)
+	// GetReceiptsByHash returns the receipts by block number and hash
+	GetReceiptsByHash(uint64, types.Hash) ([]*types.Receipt, error)
 
 	// ReadTxLookup returns a block hash in which a given txn was mined
 	ReadTxLookup(txnHash types.Hash) (uint64, bool)
@@ -680,7 +680,7 @@ func (d *Debug) GetRawReceipts(filter BlockNumberOrHash) (interface{}, error) {
 				return nil, err
 			}
 
-			receipts, err := d.store.GetReceiptsByHash(header.Hash)
+			receipts, err := d.store.GetReceiptsByHash(header.Number, header.Hash)
 			if err != nil {
 				return nil, err
 			}

--- a/jsonrpc/debug_endpoint_test.go
+++ b/jsonrpc/debug_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 type debugEndpointMockStore struct {
 	headerFn              func() *types.Header
 	getHeaderByNumberFn   func(uint64) (*types.Header, bool)
-	getReceiptsByHashFn   func(types.Hash) ([]*types.Receipt, error)
+	getReceiptsByHashFn   func(uint64, types.Hash) ([]*types.Receipt, error)
 	readTxLookupFn        func(types.Hash) (uint64, bool)
 	getPendingTxFn        func(types.Hash) (*types.Transaction, bool)
 	hasFn                 func(types.Hash) bool
@@ -51,8 +51,8 @@ func (s *debugEndpointMockStore) GetHeaderByNumber(num uint64) (*types.Header, b
 	return s.getHeaderByNumberFn(num)
 }
 
-func (s *debugEndpointMockStore) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
-	return s.getReceiptsByHashFn(hash)
+func (s *debugEndpointMockStore) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
+	return s.getReceiptsByHashFn(num, hash)
 }
 
 func (s *debugEndpointMockStore) ReadTxLookup(txnHash types.Hash) (uint64, bool) {
@@ -1231,7 +1231,7 @@ func TestGetRawReceipts(t *testing.T) {
 				getBlockByHashFn: func(hash types.Hash, full bool) (*types.Block, bool) {
 					return testLatestBlock, true
 				},
-				getReceiptsByHashFn: func(hash types.Hash) ([]*types.Receipt, error) {
+				getReceiptsByHashFn: func(num uint64, hash types.Hash) ([]*types.Receipt, error) {
 					return nil, fmt.Errorf("receipts not found")
 				},
 			},
@@ -1252,7 +1252,7 @@ func TestGetRawReceipts(t *testing.T) {
 					return testLatestBlock, true
 				},
 
-				getReceiptsByHashFn: func(hash types.Hash) ([]*types.Receipt, error) {
+				getReceiptsByHashFn: func(num uint64, hash types.Hash) ([]*types.Receipt, error) {
 					return receipts, nil
 				},
 			},

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -68,6 +68,9 @@ type dispatcherParams struct {
 	blockRangeLimit         uint64
 
 	concurrentRequestsDebug uint64
+
+	blockCacheTTL      time.Duration
+	blockCacheCapacity uint64
 }
 
 func (dp dispatcherParams) isExceedingBatchLengthLimit(value uint64) bool {
@@ -105,7 +108,7 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore, manager accounts.Acco
 		d.filterManager,
 		d.params.priceLimit,
 		manager,
-		initRPCCache(store, d.logger),
+		initRPCCache(store, d.logger, d.params.blockCacheTTL, d.params.blockCacheCapacity),
 	}
 	d.endpoints.Net = &Net{
 		store,

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -105,6 +105,7 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore, manager accounts.Acco
 		d.filterManager,
 		d.params.priceLimit,
 		manager,
+		initRPCCache(store),
 	}
 	d.endpoints.Net = &Net{
 		store,

--- a/jsonrpc/dispatcher.go
+++ b/jsonrpc/dispatcher.go
@@ -105,7 +105,7 @@ func (d *Dispatcher) registerEndpoints(store JSONRPCStore, manager accounts.Acco
 		d.filterManager,
 		d.params.priceLimit,
 		manager,
-		initRPCCache(store),
+		initRPCCache(store, d.logger),
 	}
 	d.endpoints.Net = &Net{
 		store,

--- a/jsonrpc/eth_blockchain_test.go
+++ b/jsonrpc/eth_blockchain_test.go
@@ -836,7 +836,7 @@ func (m *mockBlockStore) setupLogs() {
 	}
 }
 
-func (m *mockBlockStore) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+func (m *mockBlockStore) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
 	receipts, ok := m.receipts[hash]
 	if !ok {
 		return nil, nil

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -63,8 +63,8 @@ type ethBlockchainStore interface {
 	// ReadTxLookup returns a block hash in which a given txn was mined
 	ReadTxLookup(txnHash types.Hash) (uint64, bool)
 
-	// GetReceiptsByHash returns the receipts for a block hash
-	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+	// GetReceiptsByHash returns the receipts for a block number and hash
+	GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error)
 
 	// GetAvgGasPrice returns the average gas price
 	GetAvgGasPrice() *big.Int
@@ -470,7 +470,7 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 
-	receipts, err := e.store.GetReceiptsByHash(block.Hash())
+	receipts, err := e.store.GetReceiptsByHash(blockNum, block.Hash())
 	if err != nil {
 		// block receipts not found
 		e.logger.Warn(
@@ -525,7 +525,7 @@ func (e *Eth) GetBlockReceipts(number BlockNumber) (interface{}, error) {
 		return nil, nil
 	}
 
-	receipts, err := e.store.GetReceiptsByHash(block.Hash())
+	receipts, err := e.store.GetReceiptsByHash(num, block.Hash())
 	if err != nil {
 		return nil, err
 	}

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -103,6 +103,7 @@ type Eth struct {
 	filterManager *FilterManager
 	priceLimit    uint64
 	accManager    accounts.AccountManager
+	cache         *rpcCache
 }
 
 // ChainId returns the chain id of the client
@@ -460,9 +461,9 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 
-	block, ok := e.store.GetBlockByNumber(blockNum, true)
-	if !ok {
-		// block not found
+	blockCache := e.cache.getBlockCache(blockNum)
+	if blockCache == nil {
+		// block or receipts not found
 		e.logger.Warn(
 			fmt.Sprintf("Block with number [%d] not found", blockNum),
 		)
@@ -470,16 +471,9 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 
-	receipts, err := e.store.GetReceiptsByHash(blockNum, block.Hash())
-	if err != nil {
-		// block receipts not found
-		e.logger.Warn(
-			fmt.Sprintf("Receipts for block with hash [%s] not found", block.Hash().String()),
-		)
+	block := blockCache.getBlock()
 
-		return nil, nil
-	}
-
+	receipts := blockCache.getReceipts()
 	if len(receipts) == 0 {
 		// Receipts not written yet on the db
 		e.logger.Warn(
@@ -489,20 +483,13 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 		return nil, nil
 	}
 	// find the transaction in the body
-	logIndex := 0
-	txn, txIndex := types.FindTxByHash(block.Transactions, hash)
-
+	txn, txIndex := blockCache.getTransaction(hash)
 	if txIndex == -1 {
 		// txn not found
 		return nil, nil
 	}
 
-	for i := 0; i < txIndex; i++ {
-		// accumulate receipt logs indexes from block transactions
-		// that are before the desired transaction
-		logIndex += len(receipts[i].Logs)
-	}
-
+	logIndex := blockCache.getLogIndex(txIndex)
 	raw := receipts[txIndex]
 	logs := toLogs(raw.Logs, uint64(logIndex), uint64(txIndex), block.Header, hash)
 

--- a/jsonrpc/eth_endpoint.go
+++ b/jsonrpc/eth_endpoint.go
@@ -490,6 +490,11 @@ func (e *Eth) GetTransactionReceipt(hash types.Hash) (interface{}, error) {
 	}
 
 	logIndex := blockCache.getLogIndex(txIndex)
+	if logIndex == -1 {
+		// this can't happen
+		return nil, nil
+	}
+
 	raw := receipts[txIndex]
 	logs := toLogs(raw.Logs, uint64(logIndex), uint64(txIndex), block.Header, hash)
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -288,13 +288,13 @@ func TestEth_TxnType(t *testing.T) {
 
 func newTestEthEndpoint(store testStore) *Eth {
 	return &Eth{
-		hclog.NewNullLogger(), store, 100, nil, 0, nil,
+		hclog.NewNullLogger(), store, 100, nil, 0, nil, nil,
 	}
 }
 
 func newTestEthEndpointWithPriceLimit(store testStore, priceLimit uint64) *Eth {
 	return &Eth{
-		hclog.NewNullLogger(), store, 100, nil, priceLimit, nil,
+		hclog.NewNullLogger(), store, 100, nil, priceLimit, nil, nil,
 	}
 }
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -288,7 +288,7 @@ func TestEth_TxnType(t *testing.T) {
 
 func newTestEthEndpoint(store testStore) *Eth {
 	return &Eth{
-		hclog.NewNullLogger(), store, 100, nil, 0, nil, nil,
+		hclog.NewNullLogger(), store, 100, nil, 0, nil, initRPCCache(store, hclog.NewNullLogger()),
 	}
 }
 

--- a/jsonrpc/eth_endpoint_test.go
+++ b/jsonrpc/eth_endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/polygon-edge/types"
 	"github.com/hashicorp/go-hclog"
@@ -288,7 +289,7 @@ func TestEth_TxnType(t *testing.T) {
 
 func newTestEthEndpoint(store testStore) *Eth {
 	return &Eth{
-		hclog.NewNullLogger(), store, 100, nil, 0, nil, initRPCCache(store, hclog.NewNullLogger()),
+		hclog.NewNullLogger(), store, 100, nil, 0, nil, initRPCCache(store, hclog.NewNullLogger(), time.Minute, 10),
 	}
 }
 

--- a/jsonrpc/filter_manager.go
+++ b/jsonrpc/filter_manager.go
@@ -299,8 +299,8 @@ type filterManagerStore interface {
 	// SubscribeEvents subscribes for chain head events
 	SubscribeEvents() blockchain.Subscription
 
-	// GetReceiptsByHash returns the receipts for a block hash
-	GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error)
+	// GetReceiptsByHash returns the receipts for a block number and hash
+	GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error)
 
 	// GetBlockByHash returns the block using the block hash
 	GetBlockByHash(hash types.Hash, full bool) (*types.Block, bool)
@@ -485,7 +485,7 @@ func (f *FilterManager) Exists(id string) bool {
 }
 
 func (f *FilterManager) getLogsFromBlock(query *LogQuery, block *types.Block) ([]*Log, error) {
-	receipts, err := f.store.GetReceiptsByHash(block.Header.Hash)
+	receipts, err := f.store.GetReceiptsByHash(block.Number(), block.Hash())
 	if err != nil {
 		return nil, err
 	}
@@ -780,7 +780,7 @@ func (f *FilterManager) processBlockEvent(evnt *blockchain.Event) {
 
 // appendLogsToFilters makes each LogFilters append logs in the header
 func (f *FilterManager) appendLogsToFilters(header *block) error {
-	receipts, err := f.store.GetReceiptsByHash(header.Hash)
+	receipts, err := f.store.GetReceiptsByHash(uint64(header.Number), header.Hash)
 	if err != nil {
 		return err
 	}

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -57,6 +57,9 @@ type Config struct {
 	TLSCertFile             string
 	TLSKeyFile              string
 	SecretsManager          secrets.SecretsManager
+
+	BlockCacheTTL      time.Duration
+	BlockCacheCapacity uint64
 }
 
 // NewJSONRPC returns the JSONRPC http server
@@ -71,6 +74,8 @@ func NewJSONRPC(logger hclog.Logger, config *Config, manager accounts.AccountMan
 			jsonRPCBatchLengthLimit: config.BatchLengthLimit,
 			blockRangeLimit:         config.BlockRangeLimit,
 			concurrentRequestsDebug: config.ConcurrentRequestsDebug,
+			blockCacheTTL:           config.BlockCacheTTL,
+			blockCacheCapacity:      config.BlockCacheCapacity,
 		},
 		manager,
 	)

--- a/jsonrpc/mocks_test.go
+++ b/jsonrpc/mocks_test.go
@@ -136,7 +136,7 @@ func (m *mockStore) Header() *types.Header {
 	return m.header
 }
 
-func (m *mockStore) GetReceiptsByHash(hash types.Hash) ([]*types.Receipt, error) {
+func (m *mockStore) GetReceiptsByHash(num uint64, hash types.Hash) ([]*types.Receipt, error) {
 	m.receiptsLock.Lock()
 	defer m.receiptsLock.Unlock()
 

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -1,0 +1,114 @@
+package jsonrpc
+
+import (
+	"time"
+
+	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/jellydator/ttlcache/v3"
+)
+
+type blockCache struct {
+	fullBlock *types.FullBlock
+
+	txHashToIndex map[types.Hash]int
+	logIndex      []int
+}
+
+type rpcCache struct {
+	blockCache *ttlcache.Cache[uint64, *blockCache]
+
+	store JSONRPCStore
+}
+
+func initRPCCache(store JSONRPCStore) *rpcCache {
+	cache := ttlcache.New[uint64, *blockCache](
+		ttlcache.WithTTL[uint64, *blockCache](3*time.Minute),
+		ttlcache.WithCapacity[uint64, *blockCache](50),
+	)
+
+	go cache.Start() // starts automatic expired item deletion
+
+	return &rpcCache{blockCache: cache, store: store}
+}
+
+func (r *rpcCache) getBlockCache(num uint64) *blockCache {
+	if r.blockCache.Has(num) {
+		return r.blockCache.Get(num).Value()
+	}
+
+	// load block
+	block, ok := r.store.GetBlockByNumber(num, true)
+	if !ok {
+		return nil
+	}
+
+	// load receipts
+	receipts, err := r.store.GetReceiptsByHash(num, block.Hash())
+	if err != nil {
+		// block receipts not found
+		return nil
+	}
+
+	fullBlock := &types.FullBlock{Block: block, Receipts: receipts}
+	retVal := &blockCache{fullBlock: fullBlock}
+
+	// don't cache small blocks, so return at this place with block and receipts
+	if len(block.Transactions) < 10 {
+		return retVal
+	}
+
+	txHashToIndex := map[types.Hash]int{}
+	logIndex := []int{}
+	index := 0
+	// calculate txs indexes and receipts offset
+	for i, txn := range block.Transactions {
+		txHashToIndex[txn.Hash()] = i
+		logIndex[i] = index
+		index += len(receipts[i].Logs)
+	}
+
+	retVal.txHashToIndex = txHashToIndex
+	retVal.logIndex = logIndex
+
+	r.blockCache.Set(num, retVal, ttlcache.DefaultTTL)
+
+	return retVal
+}
+
+func (b *blockCache) getBlock() *types.Block {
+	return b.fullBlock.Block
+}
+
+func (b *blockCache) getReceipts() []*types.Receipt {
+	return b.fullBlock.Receipts
+}
+
+func (b *blockCache) getTransaction(hash types.Hash) (*types.Transaction, int) {
+	if b.txHashToIndex != nil {
+		index, ok := b.txHashToIndex[hash]
+		if !ok {
+			return nil, -1
+		}
+
+		tx := b.fullBlock.Block.Transactions[index]
+
+		return tx, index
+	}
+
+	return types.FindTxByHash(b.fullBlock.Block.Transactions, hash)
+}
+
+func (b *blockCache) getLogIndex(txIndex int) int {
+	if b.logIndex != nil {
+		return b.logIndex[txIndex]
+	}
+
+	logIndex := 0
+	for i := 0; i < txIndex; i++ {
+		// accumulate receipt logs indexes from block transactions
+		// that are before the desired transaction
+		logIndex += len(b.fullBlock.Receipts[i].Logs)
+	}
+
+	return logIndex
+}

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -22,10 +22,10 @@ type rpcCache struct {
 	logger hclog.Logger
 }
 
-func initRPCCache(store ethStore, logger hclog.Logger) *rpcCache {
+func initRPCCache(store ethStore, logger hclog.Logger, ttl time.Duration, capacity uint64) *rpcCache {
 	cache := ttlcache.New[uint64, *blockCache](
-		ttlcache.WithTTL[uint64, *blockCache](3*time.Minute),
-		ttlcache.WithCapacity[uint64, *blockCache](50),
+		ttlcache.WithTTL[uint64, *blockCache](ttl),
+		ttlcache.WithCapacity[uint64, *blockCache](capacity),
 	)
 
 	go cache.Start() // starts automatic expired item deletion

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -58,7 +58,7 @@ func (r *rpcCache) getBlockCache(num uint64) *blockCache {
 	}
 
 	txHashToIndex := map[types.Hash]int{}
-	logIndex := []int{}
+	logIndex := make([]int, len(block.Transactions))
 	index := 0
 	// calculate txs indexes and receipts offset
 	for i, txn := range block.Transactions {

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -18,11 +18,11 @@ type blockCache struct {
 type rpcCache struct {
 	blockCache *ttlcache.Cache[uint64, *blockCache]
 
-	store  JSONRPCStore
+	store  ethStore
 	logger hclog.Logger
 }
 
-func initRPCCache(store JSONRPCStore, logger hclog.Logger) *rpcCache {
+func initRPCCache(store ethStore, logger hclog.Logger) *rpcCache {
 	cache := ttlcache.New[uint64, *blockCache](
 		ttlcache.WithTTL[uint64, *blockCache](3*time.Minute),
 		ttlcache.WithCapacity[uint64, *blockCache](50),

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -61,7 +61,7 @@ func (r *rpcCache) getBlockCache(num uint64) *blockCache {
 		return retVal
 	}
 
-	txHashToIndex := map[types.Hash]int{}
+	txHashToIndex := make(map[types.Hash]int, len(block.Transactions))
 	logIndex := make([]int, len(block.Transactions))
 	index := 0
 	// calculate txs indexes and receipts offset
@@ -104,8 +104,16 @@ func (b *blockCache) getTransaction(hash types.Hash) (*types.Transaction, int) {
 }
 
 func (b *blockCache) getLogIndex(txIndex int) int {
+	if txIndex < 0 {
+		return -1
+	}
+
 	if b.logIndex != nil {
-		return b.logIndex[txIndex]
+		if txIndex < len(b.logIndex) {
+			return b.logIndex[txIndex]
+		} else {
+			return -1
+		}
 	}
 
 	logIndex := 0

--- a/jsonrpc/rpccache.go
+++ b/jsonrpc/rpccache.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/0xPolygon/polygon-edge/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/jellydator/ttlcache/v3"
 )
 
@@ -17,10 +18,11 @@ type blockCache struct {
 type rpcCache struct {
 	blockCache *ttlcache.Cache[uint64, *blockCache]
 
-	store JSONRPCStore
+	store  JSONRPCStore
+	logger hclog.Logger
 }
 
-func initRPCCache(store JSONRPCStore) *rpcCache {
+func initRPCCache(store JSONRPCStore, logger hclog.Logger) *rpcCache {
 	cache := ttlcache.New[uint64, *blockCache](
 		ttlcache.WithTTL[uint64, *blockCache](3*time.Minute),
 		ttlcache.WithCapacity[uint64, *blockCache](50),
@@ -28,10 +30,12 @@ func initRPCCache(store JSONRPCStore) *rpcCache {
 
 	go cache.Start() // starts automatic expired item deletion
 
-	return &rpcCache{blockCache: cache, store: store}
+	return &rpcCache{blockCache: cache, store: store, logger: logger}
 }
 
 func (r *rpcCache) getBlockCache(num uint64) *blockCache {
+	r.logger.Debug("rpccache", "getBlockCache called with block number", num)
+
 	if r.blockCache.Has(num) {
 		return r.blockCache.Get(num).Value()
 	}
@@ -71,6 +75,7 @@ func (r *rpcCache) getBlockCache(num uint64) *blockCache {
 	retVal.logIndex = logIndex
 
 	r.blockCache.Set(num, retVal, ttlcache.DefaultTTL)
+	r.logger.Debug("rpccache", "added to cache block with number", num)
 
 	return retVal
 }

--- a/server/config.go
+++ b/server/config.go
@@ -57,6 +57,10 @@ type Config struct {
 	EventTracker *EventTracker
 
 	DBEngine string
+
+	BlockCacheTTL time.Duration
+
+	BlockCacheCapacity uint64
 }
 
 // Telemetry holds the config details for metric services

--- a/server/server.go
+++ b/server/server.go
@@ -1149,6 +1149,8 @@ func (s *Server) setupJSONRPC() error {
 		TLSCertFile:              s.config.TLSCertFile,
 		TLSKeyFile:               s.config.TLSKeyFile,
 		SecretsManager:           s.secretsManager,
+		BlockCacheTTL:            s.config.BlockCacheTTL,
+		BlockCacheCapacity:       s.config.BlockCacheCapacity,
 	}
 
 	srv, err := jsonrpc.NewJSONRPC(s.logger, conf, s.accManager)

--- a/tests/trie_benchmark_test.go
+++ b/tests/trie_benchmark_test.go
@@ -56,7 +56,7 @@ func BenchmarkTriePebbleDb(b *testing.B) {
 
 	startProfiler()
 
-	executeTrieDbTest(b, PebbleDB, 5)
+	executeTrieDbTest(b, PebbleDB, 6)
 }
 
 func BenchmarkTrieLevelDb(b *testing.B) {


### PR DESCRIPTION
# Description

In order to provide performance improvements for full node(s) exposed to BlockScout GetTransactionReceipt method will cache its result, i.e. FullBlock and transaction hash to index mapping and log index. BlockScout needs to index all block transactions and for every transaction GetTransactionReceipt is called, In order to retrieve result a transaction has to be found within block transactions array with range loop. Large blocks (with numerous txs) will consume a lot of time because number of iterations is sum of len(transactions), i.e. n/2*(n+1). For block with 10k txs total number of iterations is  50.005.000 and in addition there is another loop for log index calculation, so in total 100.010.000 and that takes about 15 minutes to complete.
 
With this solution a full block with all additional data will be cached during 1st access and kept for further requests. This reduces time needed for all GetTransactionReceipt calls several thousand times. Additionally obsolete database call is removed considering that block number is known when GetReceiptsByHash is called.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [x] I have tested this code with the official test suite
- [ ] I have tested this code manually